### PR TITLE
Add AST serializer with golden tests and fix review issues

### DIFF
--- a/bazaar-parser/build.gradle.kts
+++ b/bazaar-parser/build.gradle.kts
@@ -39,3 +39,9 @@ kotlin {
                 }
         }
 }
+
+tasks.withType<Test> {
+        systemProperty("record", System.getProperty("record") ?: "false")
+        systemProperty("testdata.dir",
+                project.file("src/jvmTest/resources/testdata").absolutePath)
+}

--- a/bazaar-parser/src/commonMain/kotlin/com/bazaar/parser/ast/AstSerializer.kt
+++ b/bazaar-parser/src/commonMain/kotlin/com/bazaar/parser/ast/AstSerializer.kt
@@ -1,0 +1,567 @@
+package com.bazaar.parser.ast
+
+object AstSerializer {
+
+    fun serialize(file: BazaarFile): String {
+        val sb = StringBuilder()
+        writeFile(sb, file, 0)
+        return sb.toString()
+    }
+
+    private fun indent(sb: StringBuilder, level: Int) {
+        repeat(level) { sb.append("  ") }
+    }
+
+    private fun line(sb: StringBuilder, level: Int, text: String) {
+        indent(sb, level)
+        sb.appendLine(text)
+    }
+
+    // --- Root ---
+
+    private fun writeFile(sb: StringBuilder, file: BazaarFile, level: Int) {
+        line(sb, level, "BazaarFile")
+        file.packageDecl?.let {
+            line(sb, level + 1, "packageDecl:")
+            writePackageDecl(sb, it, level + 2)
+        }
+        if (file.imports.isNotEmpty()) {
+            line(sb, level + 1, "imports:")
+            file.imports.forEach { writeImportDecl(sb, it, level + 2) }
+        }
+        if (file.declarations.isNotEmpty()) {
+            line(sb, level + 1, "declarations:")
+            file.declarations.forEach { writeDecl(sb, it, level + 2) }
+        }
+    }
+
+    private fun writePackageDecl(sb: StringBuilder, decl: PackageDecl, level: Int) {
+        line(sb, level, "PackageDecl")
+        writeStringList(sb, "segments", decl.segments, level + 1)
+    }
+
+    private fun writeImportDecl(sb: StringBuilder, decl: ImportDecl, level: Int) {
+        line(sb, level, "ImportDecl")
+        writeStringList(sb, "segments", decl.segments, level + 1)
+        decl.alias?.let { line(sb, level + 1, "alias: \"$it\"") }
+    }
+
+    // --- Declarations ---
+
+    private fun writeDecl(sb: StringBuilder, decl: Decl, level: Int) {
+        when (decl) {
+            is EnumDecl -> writeEnumDecl(sb, decl, level)
+            is ComponentDecl -> writeComponentDecl(sb, decl, level)
+            is DataDecl -> writeDataDecl(sb, decl, level)
+            is ModifierDecl -> writeModifierDecl(sb, decl, level)
+            is FunctionDecl -> writeFunctionDecl(sb, decl, level)
+            is TemplateDecl -> writeTemplateDecl(sb, decl, level)
+            is PreviewDecl -> writePreviewDecl(sb, decl, level)
+        }
+    }
+
+    private fun writeEnumDecl(sb: StringBuilder, decl: EnumDecl, level: Int) {
+        line(sb, level, "EnumDecl")
+        line(sb, level + 1, "name: \"${decl.name}\"")
+        writeStringList(sb, "values", decl.values, level + 1)
+    }
+
+    private fun writeComponentDecl(sb: StringBuilder, decl: ComponentDecl, level: Int) {
+        line(sb, level, "ComponentDecl")
+        line(sb, level + 1, "name: \"${decl.name}\"")
+        writeMembers(sb, decl.members, level + 1)
+    }
+
+    private fun writeDataDecl(sb: StringBuilder, decl: DataDecl, level: Int) {
+        line(sb, level, "DataDecl")
+        line(sb, level + 1, "name: \"${decl.name}\"")
+        writeMembers(sb, decl.members, level + 1)
+    }
+
+    private fun writeModifierDecl(sb: StringBuilder, decl: ModifierDecl, level: Int) {
+        line(sb, level, "ModifierDecl")
+        line(sb, level + 1, "name: \"${decl.name}\"")
+        writeMembers(sb, decl.members, level + 1)
+    }
+
+    private fun writeFunctionDecl(sb: StringBuilder, decl: FunctionDecl, level: Int) {
+        line(sb, level, "FunctionDecl")
+        line(sb, level + 1, "name: \"${decl.name}\"")
+        writeParams(sb, decl.params, level + 1)
+        decl.returnType?.let {
+            line(sb, level + 1, "returnType:")
+            writeTypeDecl(sb, it, level + 2)
+        }
+        decl.body?.let { body ->
+            if (body.isNotEmpty()) {
+                line(sb, level + 1, "body:")
+                body.forEach { writeStmt(sb, it, level + 2) }
+            }
+        }
+    }
+
+    private fun writeTemplateDecl(sb: StringBuilder, decl: TemplateDecl, level: Int) {
+        line(sb, level, "TemplateDecl")
+        line(sb, level + 1, "name: \"${decl.name}\"")
+        writeParams(sb, decl.params, level + 1)
+        if (decl.body.isNotEmpty()) {
+            line(sb, level + 1, "body:")
+            decl.body.forEach { writeStmt(sb, it, level + 2) }
+        }
+    }
+
+    private fun writePreviewDecl(sb: StringBuilder, decl: PreviewDecl, level: Int) {
+        line(sb, level, "PreviewDecl")
+        line(sb, level + 1, "name: \"${decl.name}\"")
+        if (decl.body.isNotEmpty()) {
+            line(sb, level + 1, "body:")
+            decl.body.forEach { writeStmt(sb, it, level + 2) }
+        }
+    }
+
+    // --- Members ---
+
+    private fun writeMembers(sb: StringBuilder, members: List<MemberDecl>, level: Int) {
+        if (members.isEmpty()) return
+        line(sb, level, "members:")
+        members.forEach { writeMemberDecl(sb, it, level + 1) }
+    }
+
+    private fun writeMemberDecl(sb: StringBuilder, member: MemberDecl, level: Int) {
+        when (member) {
+            is FieldDecl -> writeFieldDecl(sb, member, level)
+            is ConstructorDecl -> writeConstructorDecl(sb, member, level)
+        }
+    }
+
+    private fun writeFieldDecl(sb: StringBuilder, decl: FieldDecl, level: Int) {
+        line(sb, level, "FieldDecl")
+        line(sb, level + 1, "name: \"${decl.name}\"")
+        line(sb, level + 1, "type:")
+        writeTypeDecl(sb, decl.type, level + 2)
+        decl.default?.let {
+            line(sb, level + 1, "default:")
+            writeExpr(sb, it, level + 2)
+        }
+    }
+
+    private fun writeConstructorDecl(sb: StringBuilder, decl: ConstructorDecl, level: Int) {
+        line(sb, level, "ConstructorDecl")
+        writeParams(sb, decl.params, level + 1)
+        line(sb, level + 1, "value:")
+        writeExpr(sb, decl.value, level + 2)
+    }
+
+    // --- Parameters ---
+
+    private fun writeParams(sb: StringBuilder, params: List<ParameterDecl>, level: Int) {
+        if (params.isEmpty()) return
+        line(sb, level, "params:")
+        params.forEach { writeParameterDecl(sb, it, level + 1) }
+    }
+
+    private fun writeParameterDecl(sb: StringBuilder, decl: ParameterDecl, level: Int) {
+        line(sb, level, "ParameterDecl")
+        line(sb, level + 1, "name: \"${decl.name}\"")
+        line(sb, level + 1, "type:")
+        writeTypeDecl(sb, decl.type, level + 2)
+        decl.default?.let {
+            line(sb, level + 1, "default:")
+            writeExpr(sb, it, level + 2)
+        }
+    }
+
+    // --- Types ---
+
+    private fun writeTypeDecl(sb: StringBuilder, type: TypeDecl, level: Int) {
+        when (type) {
+            is ValueType -> {
+                line(sb, level, "ValueType")
+                line(sb, level + 1, "name: \"${type.name}\"")
+                if (type.nullable) line(sb, level + 1, "nullable: true")
+            }
+            is FunctionType -> {
+                line(sb, level, "FunctionType")
+                if (type.paramTypes.isNotEmpty()) {
+                    line(sb, level + 1, "paramTypes:")
+                    type.paramTypes.forEach { writeTypeDecl(sb, it, level + 2) }
+                }
+                type.returnType?.let {
+                    line(sb, level + 1, "returnType:")
+                    writeTypeDecl(sb, it, level + 2)
+                }
+                if (type.nullable) line(sb, level + 1, "nullable: true")
+            }
+            is ArrayType -> {
+                line(sb, level, "ArrayType")
+                line(sb, level + 1, "elementType:")
+                writeTypeDecl(sb, type.elementType, level + 2)
+                if (type.nullable) line(sb, level + 1, "nullable: true")
+            }
+            is MapType -> {
+                line(sb, level, "MapType")
+                line(sb, level + 1, "keyType:")
+                writeTypeDecl(sb, type.keyType, level + 2)
+                line(sb, level + 1, "valueType:")
+                writeTypeDecl(sb, type.valueType, level + 2)
+                if (type.nullable) line(sb, level + 1, "nullable: true")
+            }
+        }
+    }
+
+    // --- Expressions ---
+
+    private fun writeExpr(sb: StringBuilder, expr: Expr, level: Int) {
+        when (expr) {
+            is BinaryExpr -> writeBinaryExpr(sb, expr, level)
+            is UnaryExpr -> writeUnaryExpr(sb, expr, level)
+            is ReferenceExpr -> writeReferenceExpr(sb, expr, level)
+            is MemberExpr -> writeMemberExpr(sb, expr, level)
+            is IndexExpr -> writeIndexExpr(sb, expr, level)
+            is CallExpr -> writeCallExpr(sb, expr, level)
+            is LambdaExpr -> writeLambdaExpr(sb, expr, level)
+            is NullLiteral -> line(sb, level, "NullLiteral")
+            is BoolLiteral -> writeBoolLiteral(sb, expr, level)
+            is NumberLiteral -> writeNumberLiteral(sb, expr, level)
+            is StringLiteral -> writeStringLiteral(sb, expr, level)
+            is ArrayLiteral -> writeArrayLiteral(sb, expr, level)
+            is MapLiteral -> writeMapLiteral(sb, expr, level)
+        }
+    }
+
+    private fun writeBinaryExpr(sb: StringBuilder, expr: BinaryExpr, level: Int) {
+        line(sb, level, "BinaryExpr")
+        line(sb, level + 1, "op: ${expr.op.name}")
+        line(sb, level + 1, "left:")
+        writeExpr(sb, expr.left, level + 2)
+        line(sb, level + 1, "right:")
+        writeExpr(sb, expr.right, level + 2)
+    }
+
+    private fun writeUnaryExpr(sb: StringBuilder, expr: UnaryExpr, level: Int) {
+        line(sb, level, "UnaryExpr")
+        line(sb, level + 1, "op: ${expr.op.name}")
+        line(sb, level + 1, "operand:")
+        writeExpr(sb, expr.operand, level + 2)
+    }
+
+    private fun writeReferenceExpr(sb: StringBuilder, expr: ReferenceExpr, level: Int) {
+        line(sb, level, "ReferenceExpr")
+        line(sb, level + 1, "name: \"${expr.name}\"")
+    }
+
+    private fun writeMemberExpr(sb: StringBuilder, expr: MemberExpr, level: Int) {
+        line(sb, level, "MemberExpr")
+        line(sb, level + 1, "target:")
+        writeExpr(sb, expr.target, level + 2)
+        line(sb, level + 1, "member: \"${expr.member}\"")
+        if (expr.optional) line(sb, level + 1, "optional: true")
+    }
+
+    private fun writeIndexExpr(sb: StringBuilder, expr: IndexExpr, level: Int) {
+        line(sb, level, "IndexExpr")
+        line(sb, level + 1, "target:")
+        writeExpr(sb, expr.target, level + 2)
+        line(sb, level + 1, "index:")
+        writeExpr(sb, expr.index, level + 2)
+        if (expr.optional) line(sb, level + 1, "optional: true")
+    }
+
+    private fun writeCallExpr(sb: StringBuilder, expr: CallExpr, level: Int) {
+        line(sb, level, "CallExpr")
+        line(sb, level + 1, "target:")
+        writeExpr(sb, expr.target, level + 2)
+        if (expr.args.isNotEmpty()) {
+            line(sb, level + 1, "args:")
+            expr.args.forEach { writeArgument(sb, it, level + 2) }
+        }
+        expr.trailingLambda?.let {
+            line(sb, level + 1, "trailingLambda:")
+            writeLambdaExpr(sb, it, level + 2)
+        }
+        if (expr.optional) line(sb, level + 1, "optional: true")
+    }
+
+    private fun writeLambdaExpr(sb: StringBuilder, expr: LambdaExpr, level: Int) {
+        line(sb, level, "LambdaExpr")
+        if (expr.params.isNotEmpty()) {
+            line(sb, level + 1, "params:")
+            expr.params.forEach { writeLambdaParam(sb, it, level + 2) }
+        }
+        expr.returnType?.let {
+            line(sb, level + 1, "returnType:")
+            writeTypeDecl(sb, it, level + 2)
+        }
+        if (expr.body.isNotEmpty()) {
+            line(sb, level + 1, "body:")
+            expr.body.forEach { writeStmt(sb, it, level + 2) }
+        }
+    }
+
+    private fun writeBoolLiteral(sb: StringBuilder, expr: BoolLiteral, level: Int) {
+        line(sb, level, "BoolLiteral")
+        line(sb, level + 1, "value: ${expr.value}")
+    }
+
+    private fun writeNumberLiteral(sb: StringBuilder, expr: NumberLiteral, level: Int) {
+        line(sb, level, "NumberLiteral")
+        line(sb, level + 1, "value: \"${expr.value}\"")
+    }
+
+    private fun writeStringLiteral(sb: StringBuilder, expr: StringLiteral, level: Int) {
+        line(sb, level, "StringLiteral")
+        if (expr.parts.isNotEmpty()) {
+            line(sb, level + 1, "parts:")
+            expr.parts.forEach { writeStringPart(sb, it, level + 2) }
+        }
+    }
+
+    private fun writeArrayLiteral(sb: StringBuilder, expr: ArrayLiteral, level: Int) {
+        line(sb, level, "ArrayLiteral")
+        if (expr.elements.isNotEmpty()) {
+            line(sb, level + 1, "elements:")
+            expr.elements.forEach { writeExpr(sb, it, level + 2) }
+        }
+    }
+
+    private fun writeMapLiteral(sb: StringBuilder, expr: MapLiteral, level: Int) {
+        line(sb, level, "MapLiteral")
+        if (expr.entries.isNotEmpty()) {
+            line(sb, level + 1, "entries:")
+            expr.entries.forEach { writeMapEntry(sb, it, level + 2) }
+        }
+    }
+
+    // --- String parts ---
+
+    private fun writeStringPart(sb: StringBuilder, part: StringPart, level: Int) {
+        when (part) {
+            is TextPart -> {
+                line(sb, level, "TextPart")
+                line(sb, level + 1, "text: \"${part.text}\"")
+            }
+            is EscapePart -> {
+                line(sb, level, "EscapePart")
+                line(sb, level + 1, "text: \"${part.text}\"")
+            }
+            is InterpolationPart -> {
+                line(sb, level, "InterpolationPart")
+                line(sb, level + 1, "expr:")
+                writeExpr(sb, part.expr, level + 2)
+            }
+        }
+    }
+
+    // --- Support types ---
+
+    private fun writeArgument(sb: StringBuilder, arg: Argument, level: Int) {
+        line(sb, level, "Argument")
+        arg.name?.let { line(sb, level + 1, "name: \"$it\"") }
+        line(sb, level + 1, "value:")
+        writeExpr(sb, arg.value, level + 2)
+    }
+
+    private fun writeLambdaParam(sb: StringBuilder, param: LambdaParam, level: Int) {
+        line(sb, level, "LambdaParam")
+        line(sb, level + 1, "name: \"${param.name}\"")
+        param.type?.let {
+            line(sb, level + 1, "type:")
+            writeTypeDecl(sb, it, level + 2)
+        }
+    }
+
+    private fun writeMapEntry(sb: StringBuilder, entry: MapEntry, level: Int) {
+        line(sb, level, "MapEntry")
+        line(sb, level + 1, "key:")
+        writeExpr(sb, entry.key, level + 2)
+        line(sb, level + 1, "value:")
+        writeExpr(sb, entry.value, level + 2)
+    }
+
+    private fun writeAnnotation(sb: StringBuilder, annotation: Annotation, level: Int) {
+        line(sb, level, "Annotation")
+        line(sb, level + 1, "name: \"${annotation.name}\"")
+        annotation.args?.let { args ->
+            if (args.isNotEmpty()) {
+                line(sb, level + 1, "args:")
+                args.forEach { writeArgument(sb, it, level + 2) }
+            }
+        }
+    }
+
+    // --- Statements ---
+
+    private fun writeStmt(sb: StringBuilder, stmt: Stmt, level: Int) {
+        when (stmt) {
+            is VarDeclStmt -> writeVarDeclStmt(sb, stmt, level)
+            is AssignStmt -> writeAssignStmt(sb, stmt, level)
+            is CallStmt -> writeCallStmt(sb, stmt, level)
+            is ReturnStmt -> writeReturnStmt(sb, stmt, level)
+            is ExprStmt -> writeExprStmt(sb, stmt, level)
+            is IfStmt -> writeIfStmt(sb, stmt, level)
+            is ForInStmt -> writeForInStmt(sb, stmt, level)
+            is ForCondStmt -> writeForCondStmt(sb, stmt, level)
+            is SwitchStmt -> writeSwitchStmt(sb, stmt, level)
+        }
+    }
+
+    private fun writeVarDeclStmt(sb: StringBuilder, stmt: VarDeclStmt, level: Int) {
+        line(sb, level, "VarDeclStmt")
+        writeStringList(sb, "names", stmt.names, level + 1)
+        stmt.type?.let {
+            line(sb, level + 1, "type:")
+            writeTypeDecl(sb, it, level + 2)
+        }
+        line(sb, level + 1, "value:")
+        writeExpr(sb, stmt.value, level + 2)
+        if (stmt.annotations.isNotEmpty()) {
+            line(sb, level + 1, "annotations:")
+            stmt.annotations.forEach { writeAnnotation(sb, it, level + 2) }
+        }
+    }
+
+    private fun writeAssignStmt(sb: StringBuilder, stmt: AssignStmt, level: Int) {
+        line(sb, level, "AssignStmt")
+        line(sb, level + 1, "target: \"${stmt.target}\"")
+        line(sb, level + 1, "op: ${stmt.op.name}")
+        line(sb, level + 1, "value:")
+        writeExpr(sb, stmt.value, level + 2)
+    }
+
+    private fun writeCallStmt(sb: StringBuilder, stmt: CallStmt, level: Int) {
+        line(sb, level, "CallStmt")
+        if (stmt.annotations.isNotEmpty()) {
+            line(sb, level + 1, "annotations:")
+            stmt.annotations.forEach { writeAnnotation(sb, it, level + 2) }
+        }
+        line(sb, level + 1, "expr:")
+        writeCallExpr(sb, stmt.expr, level + 2)
+    }
+
+    private fun writeReturnStmt(sb: StringBuilder, stmt: ReturnStmt, level: Int) {
+        line(sb, level, "ReturnStmt")
+        stmt.value?.let {
+            line(sb, level + 1, "value:")
+            writeExpr(sb, it, level + 2)
+        }
+    }
+
+    private fun writeExprStmt(sb: StringBuilder, stmt: ExprStmt, level: Int) {
+        line(sb, level, "ExprStmt")
+        line(sb, level + 1, "expr:")
+        writeExpr(sb, stmt.expr, level + 2)
+    }
+
+    // --- If ---
+
+    private fun writeIfStmt(sb: StringBuilder, stmt: IfStmt, level: Int) {
+        line(sb, level, "IfStmt")
+        line(sb, level + 1, "fragments:")
+        stmt.fragments.forEach { writeIfFragment(sb, it, level + 2) }
+        if (stmt.body.isNotEmpty()) {
+            line(sb, level + 1, "body:")
+            stmt.body.forEach { writeStmt(sb, it, level + 2) }
+        }
+        if (stmt.elseIfs.isNotEmpty()) {
+            line(sb, level + 1, "elseIfs:")
+            stmt.elseIfs.forEach { writeElseIf(sb, it, level + 2) }
+        }
+        stmt.elseBody?.let { body ->
+            if (body.isNotEmpty()) {
+                line(sb, level + 1, "elseBody:")
+                body.forEach { writeStmt(sb, it, level + 2) }
+            }
+        }
+    }
+
+    private fun writeElseIf(sb: StringBuilder, elseIf: ElseIf, level: Int) {
+        line(sb, level, "ElseIf")
+        line(sb, level + 1, "fragments:")
+        elseIf.fragments.forEach { writeIfFragment(sb, it, level + 2) }
+        if (elseIf.body.isNotEmpty()) {
+            line(sb, level + 1, "body:")
+            elseIf.body.forEach { writeStmt(sb, it, level + 2) }
+        }
+    }
+
+    private fun writeIfFragment(sb: StringBuilder, fragment: IfFragment, level: Int) {
+        when (fragment) {
+            is IfVarFragment -> {
+                line(sb, level, "IfVarFragment")
+                writeStringList(sb, "names", fragment.names, level + 1)
+                fragment.type?.let {
+                    line(sb, level + 1, "type:")
+                    writeTypeDecl(sb, it, level + 2)
+                }
+                fragment.value?.let {
+                    line(sb, level + 1, "value:")
+                    writeExpr(sb, it, level + 2)
+                }
+            }
+            is IfExprFragment -> {
+                line(sb, level, "IfExprFragment")
+                line(sb, level + 1, "expr:")
+                writeExpr(sb, fragment.expr, level + 2)
+            }
+        }
+    }
+
+    // --- For ---
+
+    private fun writeForInStmt(sb: StringBuilder, stmt: ForInStmt, level: Int) {
+        line(sb, level, "ForInStmt")
+        writeStringList(sb, "names", stmt.names, level + 1)
+        line(sb, level + 1, "iterable:")
+        writeExpr(sb, stmt.iterable, level + 2)
+        if (stmt.body.isNotEmpty()) {
+            line(sb, level + 1, "body:")
+            stmt.body.forEach { writeStmt(sb, it, level + 2) }
+        }
+    }
+
+    private fun writeForCondStmt(sb: StringBuilder, stmt: ForCondStmt, level: Int) {
+        line(sb, level, "ForCondStmt")
+        line(sb, level + 1, "condition:")
+        writeExpr(sb, stmt.condition, level + 2)
+        if (stmt.body.isNotEmpty()) {
+            line(sb, level + 1, "body:")
+            stmt.body.forEach { writeStmt(sb, it, level + 2) }
+        }
+    }
+
+    // --- Switch ---
+
+    private fun writeSwitchStmt(sb: StringBuilder, stmt: SwitchStmt, level: Int) {
+        line(sb, level, "SwitchStmt")
+        line(sb, level + 1, "expr:")
+        writeExpr(sb, stmt.expr, level + 2)
+        if (stmt.cases.isNotEmpty()) {
+            line(sb, level + 1, "cases:")
+            stmt.cases.forEach { writeSwitchCase(sb, it, level + 2) }
+        }
+        stmt.default?.let { body ->
+            if (body.isNotEmpty()) {
+                line(sb, level + 1, "default:")
+                body.forEach { writeStmt(sb, it, level + 2) }
+            }
+        }
+    }
+
+    private fun writeSwitchCase(sb: StringBuilder, case: SwitchCase, level: Int) {
+        line(sb, level, "SwitchCase")
+        line(sb, level + 1, "expr:")
+        writeExpr(sb, case.expr, level + 2)
+        if (case.body.isNotEmpty()) {
+            line(sb, level + 1, "body:")
+            case.body.forEach { writeStmt(sb, it, level + 2) }
+        }
+    }
+
+    // --- Helpers ---
+
+    private fun writeStringList(sb: StringBuilder, name: String, values: List<String>, level: Int) {
+        if (values.isEmpty()) return
+        val quoted = values.joinToString(", ") { "\"$it\"" }
+        line(sb, level, "$name: [$quoted]")
+    }
+}

--- a/bazaar-parser/src/commonTest/kotlin/com/bazaar/parser/ast/AstSerializerTest.kt
+++ b/bazaar-parser/src/commonTest/kotlin/com/bazaar/parser/ast/AstSerializerTest.kt
@@ -1,0 +1,265 @@
+package com.bazaar.parser.ast
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AstSerializerTest {
+
+    @Test
+    fun emptyFile() {
+        val file = BazaarFile()
+        assertEquals(
+            "BazaarFile\n",
+            AstSerializer.serialize(file),
+        )
+    }
+
+    @Test
+    fun packageDecl() {
+        val file = BazaarFile(packageDecl = PackageDecl(listOf("com", "example")))
+        assertEquals(
+            """
+            BazaarFile
+              packageDecl:
+                PackageDecl
+                  segments: ["com", "example"]
+            """.trimIndent() + "\n",
+            AstSerializer.serialize(file),
+        )
+    }
+
+    @Test
+    fun imports() {
+        val file = BazaarFile(
+            imports = listOf(
+                ImportDecl(listOf("layout")),
+                ImportDecl(listOf("com", "example", "utils"), alias = "u"),
+            ),
+        )
+        assertEquals(
+            """
+            BazaarFile
+              imports:
+                ImportDecl
+                  segments: ["layout"]
+                ImportDecl
+                  segments: ["com", "example", "utils"]
+                  alias: "u"
+            """.trimIndent() + "\n",
+            AstSerializer.serialize(file),
+        )
+    }
+
+    @Test
+    fun enumDecl() {
+        val file = BazaarFile(
+            declarations = listOf(
+                EnumDecl("Color", listOf("Red", "Green", "Blue")),
+            ),
+        )
+        assertEquals(
+            """
+            BazaarFile
+              declarations:
+                EnumDecl
+                  name: "Color"
+                  values: ["Red", "Green", "Blue"]
+            """.trimIndent() + "\n",
+            AstSerializer.serialize(file),
+        )
+    }
+
+    @Test
+    fun componentWithFields() {
+        val file = BazaarFile(
+            declarations = listOf(
+                ComponentDecl(
+                    name = "Button",
+                    members = listOf(
+                        FieldDecl(
+                            name = "label",
+                            type = ValueType("string"),
+                        ),
+                        FieldDecl(
+                            name = "onClick",
+                            type = FunctionType(emptyList(), nullable = true),
+                            default = NullLiteral,
+                        ),
+                    ),
+                ),
+            ),
+        )
+        assertEquals(
+            """
+            BazaarFile
+              declarations:
+                ComponentDecl
+                  name: "Button"
+                  members:
+                    FieldDecl
+                      name: "label"
+                      type:
+                        ValueType
+                          name: "string"
+                    FieldDecl
+                      name: "onClick"
+                      type:
+                        FunctionType
+                          nullable: true
+                      default:
+                        NullLiteral
+            """.trimIndent() + "\n",
+            AstSerializer.serialize(file),
+        )
+    }
+
+    @Test
+    fun functionDeclWithParams() {
+        val file = BazaarFile(
+            declarations = listOf(
+                FunctionDecl(
+                    name = "add",
+                    params = listOf(
+                        ParameterDecl("x", ValueType("int")),
+                        ParameterDecl("y", ValueType("int")),
+                    ),
+                    returnType = ValueType("int"),
+                ),
+            ),
+        )
+        assertEquals(
+            """
+            BazaarFile
+              declarations:
+                FunctionDecl
+                  name: "add"
+                  params:
+                    ParameterDecl
+                      name: "x"
+                      type:
+                        ValueType
+                          name: "int"
+                    ParameterDecl
+                      name: "y"
+                      type:
+                        ValueType
+                          name: "int"
+                  returnType:
+                    ValueType
+                      name: "int"
+            """.trimIndent() + "\n",
+            AstSerializer.serialize(file),
+        )
+    }
+
+    @Test
+    fun ifStatement() {
+        val file = BazaarFile(
+            declarations = listOf(
+                TemplateDecl(
+                    name = "Test",
+                    body = listOf(
+                        IfStmt(
+                            fragments = listOf(
+                                IfExprFragment(BoolLiteral(true)),
+                            ),
+                            body = listOf(
+                                ReturnStmt(),
+                            ),
+                            elseBody = listOf(
+                                ReturnStmt(NumberLiteral("0")),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        assertEquals(
+            """
+            BazaarFile
+              declarations:
+                TemplateDecl
+                  name: "Test"
+                  body:
+                    IfStmt
+                      fragments:
+                        IfExprFragment
+                          expr:
+                            BoolLiteral
+                              value: true
+                      body:
+                        ReturnStmt
+                      elseBody:
+                        ReturnStmt
+                          value:
+                            NumberLiteral
+                              value: "0"
+            """.trimIndent() + "\n",
+            AstSerializer.serialize(file),
+        )
+    }
+
+    @Test
+    fun nullLiteral() {
+        val file = BazaarFile(
+            declarations = listOf(
+                FunctionDecl(
+                    name = "f",
+                    body = listOf(
+                        ReturnStmt(NullLiteral),
+                    ),
+                ),
+            ),
+        )
+        val result = AstSerializer.serialize(file)
+        assertTrue(result.contains("NullLiteral"), "Should contain NullLiteral")
+        assertFalse(result.contains("NullLiteral\n            value:"), "NullLiteral should have no children")
+    }
+
+    @Test
+    fun memberExprWithOptional() {
+        val expr = MemberExpr(
+            target = ReferenceExpr("foo"),
+            member = "bar",
+            optional = true,
+        )
+        val file = BazaarFile(
+            declarations = listOf(
+                FunctionDecl(
+                    name = "f",
+                    body = listOf(ExprStmt(expr)),
+                ),
+            ),
+        )
+        val result = AstSerializer.serialize(file)
+        assertTrue(result.contains("optional: true"), "Should contain optional: true")
+    }
+
+    @Test
+    fun stringLiteralWithParts() {
+        val file = BazaarFile(
+            declarations = listOf(
+                FunctionDecl(
+                    name = "f",
+                    body = listOf(
+                        ExprStmt(
+                            StringLiteral(
+                                listOf(
+                                    TextPart("hello "),
+                                    InterpolationPart(ReferenceExpr("name")),
+                                    EscapePart("\\n"),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val result = AstSerializer.serialize(file)
+        assertTrue(result.contains("TextPart"), "Should contain TextPart")
+        assertTrue(result.contains("InterpolationPart"), "Should contain InterpolationPart")
+        assertTrue(result.contains("EscapePart"), "Should contain EscapePart")
+    }
+}

--- a/bazaar-parser/src/jvmTest/kotlin/com/bazaar/parser/AstGoldenTest.kt
+++ b/bazaar-parser/src/jvmTest/kotlin/com/bazaar/parser/AstGoldenTest.kt
@@ -1,0 +1,69 @@
+package com.bazaar.parser
+
+import com.bazaar.parser.ast.AstSerializer
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class AstGoldenTest {
+
+    private val record = System.getProperty("record") == "true"
+    private val testdataDir = System.getProperty("testdata.dir")
+        ?: error("testdata.dir system property not set")
+
+    private fun goldenTest(name: String) {
+        val source = javaClass.getResourceAsStream("/testdata/$name.bzr")
+            ?.bufferedReader()?.readText()
+            ?: fail("Test file not found: /testdata/$name.bzr")
+
+        val ast = BazaarParser.parse(source)
+        val actual = AstSerializer.serialize(ast)
+
+        val goldenFile = File(testdataDir, "$name.bzr.ast.golden")
+
+        if (record) {
+            goldenFile.writeText(actual)
+            println("Recorded golden file: ${goldenFile.absolutePath}")
+            return
+        }
+
+        if (!goldenFile.exists()) {
+            // Try classpath as fallback
+            val classpathGolden = javaClass.getResourceAsStream("/testdata/$name.bzr.ast.golden")
+                ?.bufferedReader()?.readText()
+            if (classpathGolden == null) {
+                fail(
+                    "Golden file not found: ${goldenFile.absolutePath}\n" +
+                        "Run with -Drecord=true to generate it.",
+                )
+            }
+            assertEquals(classpathGolden, actual, "AST mismatch for $name")
+        } else {
+            val expected = goldenFile.readText()
+            assertEquals(expected, actual, "AST mismatch for $name")
+        }
+    }
+
+    @Test fun annotations() = goldenTest("annotations")
+    @Test fun arithmetic() = goldenTest("arithmetic")
+    @Test fun arrays() = goldenTest("arrays")
+    @Test fun assigns() = goldenTest("assigns")
+    @Test fun builtins() = goldenTest("builtins")
+    @Test fun calls() = goldenTest("calls")
+    @Test fun edgeCases() = goldenTest("edge-cases")
+    @Test fun example() = goldenTest("example")
+    @Test fun fors() = goldenTest("fors")
+    @Test fun functions() = goldenTest("functions")
+    @Test fun ifs() = goldenTest("ifs")
+    @Test fun imports() = goldenTest("imports")
+    @Test fun lambdas() = goldenTest("lambdas")
+    @Test fun maps() = goldenTest("maps")
+    @Test fun operators() = goldenTest("operators")
+    @Test fun optionalChaining() = goldenTest("optional-chaining")
+    @Test fun references() = goldenTest("references")
+    @Test fun scientific() = goldenTest("scientific")
+    @Test fun strings() = goldenTest("strings")
+    @Test fun switches() = goldenTest("switches")
+    @Test fun todo() = goldenTest("todo")
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/annotations.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/annotations.bzr
@@ -1,0 +1,18 @@
+package annotations
+
+func MultipleAnnotations() {
+    // Multiple annotations work on function calls
+    @State @Modifier(Padding(all = 42)) @Custom
+    SomeFunction()
+
+    // Single annotations work on both calls and variables
+    @State
+    AnotherFunction()
+
+    @State
+    var singleVar = 1
+
+    // Multiple annotations work on function calls with parameters
+    @Logger @Async @Retry
+    ProcessData("input", param2 = 42)
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/annotations.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/annotations.bzr.ast.golden
@@ -1,0 +1,76 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["annotations"]
+  declarations:
+    FunctionDecl
+      name: "MultipleAnnotations"
+      body:
+        CallStmt
+          annotations:
+            Annotation
+              name: "State"
+            Annotation
+              name: "Modifier"
+              args:
+                Argument
+                  value:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "Padding"
+                      args:
+                        Argument
+                          name: "all"
+                          value:
+                            NumberLiteral
+                              value: "42"
+            Annotation
+              name: "Custom"
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "SomeFunction"
+        CallStmt
+          annotations:
+            Annotation
+              name: "State"
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "AnotherFunction"
+        VarDeclStmt
+          names: ["singleVar"]
+          value:
+            NumberLiteral
+              value: "1"
+          annotations:
+            Annotation
+              name: "State"
+        CallStmt
+          annotations:
+            Annotation
+              name: "Logger"
+            Annotation
+              name: "Async"
+            Annotation
+              name: "Retry"
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "ProcessData"
+              args:
+                Argument
+                  value:
+                    StringLiteral
+                      parts:
+                        TextPart
+                          text: "input"
+                Argument
+                  name: "param2"
+                  value:
+                    NumberLiteral
+                      value: "42"

--- a/bazaar-parser/src/jvmTest/resources/testdata/arithmetic.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/arithmetic.bzr
@@ -1,0 +1,49 @@
+package arithmetic
+
+func Arithmetic() {
+    // Basic precedence test (existing)
+    var answer = 42*1 + 1 - 1
+
+    // Multiplication and division precedence (same level, left-to-right)
+    var mulDiv = 12 / 3 * 4
+    var divMul = 12 * 3 / 4
+
+    // Multiplication and modulo precedence (same level, left-to-right)
+    var mulMod = 10 * 3 % 7
+    var modMul = 10 % 3 * 7
+
+    // Division and modulo precedence (same level, left-to-right)
+    var divMod = 20 / 4 % 3
+    var modDiv = 20 % 6 / 2
+
+    // Mixed arithmetic precedence (*, /, % before +, -)
+    var complex1 = 2 + 3 * 4 - 5
+    var complex2 = 10 - 6 / 2 + 1
+    var complex3 = 15 + 8 % 3 * 2
+    var complex4 = 20 / 4 + 3 * 2 - 1
+
+    // All arithmetic operators together
+    var allOps = 100 + 50 - 20 * 2 / 4 % 3
+
+    // Unary minus precedence (higher than binary operators)
+    var unaryMinus1 = -5 + 3
+    var unaryMinus2 = 2 * -3
+    var unaryMinus3 = -10 / 2
+    var unaryMinus4 = -4 % 3
+
+    // Parentheses override precedence
+    var grouped1 = (2 + 3) * 4
+    var grouped2 = 2 * (3 + 4)
+    var grouped3 = (10 - 2) / (3 + 1)
+    var grouped4 = -(2 + 3) * 4
+
+    // Nested parentheses
+    var nested1 = ((2 + 3) * 4) - 1
+    var nested2 = 2 * ((10 - 6) / 2)
+    var nested3 = (5 + (3 * 2)) - (8 / 4)
+
+    // Edge cases with mixed types (integers and floats)
+    var mixedTypes1 = 10 + 3.5 * 2
+    var mixedTypes2 = 15.0 / 3 - 1
+    var mixedTypes3 = -2.5 + 5 * 2
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/arithmetic.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/arithmetic.bzr.ast.golden
@@ -1,0 +1,528 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["arithmetic"]
+  declarations:
+    FunctionDecl
+      name: "Arithmetic"
+      body:
+        VarDeclStmt
+          names: ["answer"]
+          value:
+            BinaryExpr
+              op: SUB
+              left:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    BinaryExpr
+                      op: MUL
+                      left:
+                        NumberLiteral
+                          value: "42"
+                      right:
+                        NumberLiteral
+                          value: "1"
+                  right:
+                    NumberLiteral
+                      value: "1"
+              right:
+                NumberLiteral
+                  value: "1"
+        VarDeclStmt
+          names: ["mulDiv"]
+          value:
+            BinaryExpr
+              op: MUL
+              left:
+                BinaryExpr
+                  op: DIV
+                  left:
+                    NumberLiteral
+                      value: "12"
+                  right:
+                    NumberLiteral
+                      value: "3"
+              right:
+                NumberLiteral
+                  value: "4"
+        VarDeclStmt
+          names: ["divMul"]
+          value:
+            BinaryExpr
+              op: DIV
+              left:
+                BinaryExpr
+                  op: MUL
+                  left:
+                    NumberLiteral
+                      value: "12"
+                  right:
+                    NumberLiteral
+                      value: "3"
+              right:
+                NumberLiteral
+                  value: "4"
+        VarDeclStmt
+          names: ["mulMod"]
+          value:
+            BinaryExpr
+              op: MOD
+              left:
+                BinaryExpr
+                  op: MUL
+                  left:
+                    NumberLiteral
+                      value: "10"
+                  right:
+                    NumberLiteral
+                      value: "3"
+              right:
+                NumberLiteral
+                  value: "7"
+        VarDeclStmt
+          names: ["modMul"]
+          value:
+            BinaryExpr
+              op: MUL
+              left:
+                BinaryExpr
+                  op: MOD
+                  left:
+                    NumberLiteral
+                      value: "10"
+                  right:
+                    NumberLiteral
+                      value: "3"
+              right:
+                NumberLiteral
+                  value: "7"
+        VarDeclStmt
+          names: ["divMod"]
+          value:
+            BinaryExpr
+              op: MOD
+              left:
+                BinaryExpr
+                  op: DIV
+                  left:
+                    NumberLiteral
+                      value: "20"
+                  right:
+                    NumberLiteral
+                      value: "4"
+              right:
+                NumberLiteral
+                  value: "3"
+        VarDeclStmt
+          names: ["modDiv"]
+          value:
+            BinaryExpr
+              op: DIV
+              left:
+                BinaryExpr
+                  op: MOD
+                  left:
+                    NumberLiteral
+                      value: "20"
+                  right:
+                    NumberLiteral
+                      value: "6"
+              right:
+                NumberLiteral
+                  value: "2"
+        VarDeclStmt
+          names: ["complex1"]
+          value:
+            BinaryExpr
+              op: SUB
+              left:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    NumberLiteral
+                      value: "2"
+                  right:
+                    BinaryExpr
+                      op: MUL
+                      left:
+                        NumberLiteral
+                          value: "3"
+                      right:
+                        NumberLiteral
+                          value: "4"
+              right:
+                NumberLiteral
+                  value: "5"
+        VarDeclStmt
+          names: ["complex2"]
+          value:
+            BinaryExpr
+              op: ADD
+              left:
+                BinaryExpr
+                  op: SUB
+                  left:
+                    NumberLiteral
+                      value: "10"
+                  right:
+                    BinaryExpr
+                      op: DIV
+                      left:
+                        NumberLiteral
+                          value: "6"
+                      right:
+                        NumberLiteral
+                          value: "2"
+              right:
+                NumberLiteral
+                  value: "1"
+        VarDeclStmt
+          names: ["complex3"]
+          value:
+            BinaryExpr
+              op: ADD
+              left:
+                NumberLiteral
+                  value: "15"
+              right:
+                BinaryExpr
+                  op: MUL
+                  left:
+                    BinaryExpr
+                      op: MOD
+                      left:
+                        NumberLiteral
+                          value: "8"
+                      right:
+                        NumberLiteral
+                          value: "3"
+                  right:
+                    NumberLiteral
+                      value: "2"
+        VarDeclStmt
+          names: ["complex4"]
+          value:
+            BinaryExpr
+              op: SUB
+              left:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    BinaryExpr
+                      op: DIV
+                      left:
+                        NumberLiteral
+                          value: "20"
+                      right:
+                        NumberLiteral
+                          value: "4"
+                  right:
+                    BinaryExpr
+                      op: MUL
+                      left:
+                        NumberLiteral
+                          value: "3"
+                      right:
+                        NumberLiteral
+                          value: "2"
+              right:
+                NumberLiteral
+                  value: "1"
+        VarDeclStmt
+          names: ["allOps"]
+          value:
+            BinaryExpr
+              op: SUB
+              left:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    NumberLiteral
+                      value: "100"
+                  right:
+                    NumberLiteral
+                      value: "50"
+              right:
+                BinaryExpr
+                  op: MOD
+                  left:
+                    BinaryExpr
+                      op: DIV
+                      left:
+                        BinaryExpr
+                          op: MUL
+                          left:
+                            NumberLiteral
+                              value: "20"
+                          right:
+                            NumberLiteral
+                              value: "2"
+                      right:
+                        NumberLiteral
+                          value: "4"
+                  right:
+                    NumberLiteral
+                      value: "3"
+        VarDeclStmt
+          names: ["unaryMinus1"]
+          value:
+            BinaryExpr
+              op: ADD
+              left:
+                UnaryExpr
+                  op: NEGATE
+                  operand:
+                    NumberLiteral
+                      value: "5"
+              right:
+                NumberLiteral
+                  value: "3"
+        VarDeclStmt
+          names: ["unaryMinus2"]
+          value:
+            BinaryExpr
+              op: MUL
+              left:
+                NumberLiteral
+                  value: "2"
+              right:
+                UnaryExpr
+                  op: NEGATE
+                  operand:
+                    NumberLiteral
+                      value: "3"
+        VarDeclStmt
+          names: ["unaryMinus3"]
+          value:
+            BinaryExpr
+              op: DIV
+              left:
+                UnaryExpr
+                  op: NEGATE
+                  operand:
+                    NumberLiteral
+                      value: "10"
+              right:
+                NumberLiteral
+                  value: "2"
+        VarDeclStmt
+          names: ["unaryMinus4"]
+          value:
+            BinaryExpr
+              op: MOD
+              left:
+                UnaryExpr
+                  op: NEGATE
+                  operand:
+                    NumberLiteral
+                      value: "4"
+              right:
+                NumberLiteral
+                  value: "3"
+        VarDeclStmt
+          names: ["grouped1"]
+          value:
+            BinaryExpr
+              op: MUL
+              left:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    NumberLiteral
+                      value: "2"
+                  right:
+                    NumberLiteral
+                      value: "3"
+              right:
+                NumberLiteral
+                  value: "4"
+        VarDeclStmt
+          names: ["grouped2"]
+          value:
+            BinaryExpr
+              op: MUL
+              left:
+                NumberLiteral
+                  value: "2"
+              right:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    NumberLiteral
+                      value: "3"
+                  right:
+                    NumberLiteral
+                      value: "4"
+        VarDeclStmt
+          names: ["grouped3"]
+          value:
+            BinaryExpr
+              op: DIV
+              left:
+                BinaryExpr
+                  op: SUB
+                  left:
+                    NumberLiteral
+                      value: "10"
+                  right:
+                    NumberLiteral
+                      value: "2"
+              right:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    NumberLiteral
+                      value: "3"
+                  right:
+                    NumberLiteral
+                      value: "1"
+        VarDeclStmt
+          names: ["grouped4"]
+          value:
+            BinaryExpr
+              op: MUL
+              left:
+                UnaryExpr
+                  op: NEGATE
+                  operand:
+                    BinaryExpr
+                      op: ADD
+                      left:
+                        NumberLiteral
+                          value: "2"
+                      right:
+                        NumberLiteral
+                          value: "3"
+              right:
+                NumberLiteral
+                  value: "4"
+        VarDeclStmt
+          names: ["nested1"]
+          value:
+            BinaryExpr
+              op: SUB
+              left:
+                BinaryExpr
+                  op: MUL
+                  left:
+                    BinaryExpr
+                      op: ADD
+                      left:
+                        NumberLiteral
+                          value: "2"
+                      right:
+                        NumberLiteral
+                          value: "3"
+                  right:
+                    NumberLiteral
+                      value: "4"
+              right:
+                NumberLiteral
+                  value: "1"
+        VarDeclStmt
+          names: ["nested2"]
+          value:
+            BinaryExpr
+              op: MUL
+              left:
+                NumberLiteral
+                  value: "2"
+              right:
+                BinaryExpr
+                  op: DIV
+                  left:
+                    BinaryExpr
+                      op: SUB
+                      left:
+                        NumberLiteral
+                          value: "10"
+                      right:
+                        NumberLiteral
+                          value: "6"
+                  right:
+                    NumberLiteral
+                      value: "2"
+        VarDeclStmt
+          names: ["nested3"]
+          value:
+            BinaryExpr
+              op: SUB
+              left:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    NumberLiteral
+                      value: "5"
+                  right:
+                    BinaryExpr
+                      op: MUL
+                      left:
+                        NumberLiteral
+                          value: "3"
+                      right:
+                        NumberLiteral
+                          value: "2"
+              right:
+                BinaryExpr
+                  op: DIV
+                  left:
+                    NumberLiteral
+                      value: "8"
+                  right:
+                    NumberLiteral
+                      value: "4"
+        VarDeclStmt
+          names: ["mixedTypes1"]
+          value:
+            BinaryExpr
+              op: ADD
+              left:
+                NumberLiteral
+                  value: "10"
+              right:
+                BinaryExpr
+                  op: MUL
+                  left:
+                    NumberLiteral
+                      value: "3.5"
+                  right:
+                    NumberLiteral
+                      value: "2"
+        VarDeclStmt
+          names: ["mixedTypes2"]
+          value:
+            BinaryExpr
+              op: SUB
+              left:
+                BinaryExpr
+                  op: DIV
+                  left:
+                    NumberLiteral
+                      value: "15.0"
+                  right:
+                    NumberLiteral
+                      value: "3"
+              right:
+                NumberLiteral
+                  value: "1"
+        VarDeclStmt
+          names: ["mixedTypes3"]
+          value:
+            BinaryExpr
+              op: ADD
+              left:
+                UnaryExpr
+                  op: NEGATE
+                  operand:
+                    NumberLiteral
+                      value: "2.5"
+              right:
+                BinaryExpr
+                  op: MUL
+                  left:
+                    NumberLiteral
+                      value: "5"
+                  right:
+                    NumberLiteral
+                      value: "2"

--- a/bazaar-parser/src/jvmTest/resources/testdata/arrays.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/arrays.bzr
@@ -1,0 +1,14 @@
+package arrays
+
+data ArrayFields {
+    empty [int] = []
+    singleValue [string] = ["hello, value!"]
+    trailingComma [bool] = [true,]
+    optionalValue [int?] = [null]
+    optionalArray [int]?
+}
+
+func Arrays() {
+    var emptyArray = []
+    var array = [1, 2, 3,]
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/arrays.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/arrays.bzr.ast.golden
@@ -1,0 +1,81 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["arrays"]
+  declarations:
+    DataDecl
+      name: "ArrayFields"
+      members:
+        FieldDecl
+          name: "empty"
+          type:
+            ArrayType
+              elementType:
+                ValueType
+                  name: "int"
+          default:
+            ArrayLiteral
+        FieldDecl
+          name: "singleValue"
+          type:
+            ArrayType
+              elementType:
+                ValueType
+                  name: "string"
+          default:
+            ArrayLiteral
+              elements:
+                StringLiteral
+                  parts:
+                    TextPart
+                      text: "hello, value!"
+        FieldDecl
+          name: "trailingComma"
+          type:
+            ArrayType
+              elementType:
+                ValueType
+                  name: "bool"
+          default:
+            ArrayLiteral
+              elements:
+                BoolLiteral
+                  value: true
+        FieldDecl
+          name: "optionalValue"
+          type:
+            ArrayType
+              elementType:
+                ValueType
+                  name: "int"
+                  nullable: true
+          default:
+            ArrayLiteral
+              elements:
+                NullLiteral
+        FieldDecl
+          name: "optionalArray"
+          type:
+            ArrayType
+              elementType:
+                ValueType
+                  name: "int"
+              nullable: true
+    FunctionDecl
+      name: "Arrays"
+      body:
+        VarDeclStmt
+          names: ["emptyArray"]
+          value:
+            ArrayLiteral
+        VarDeclStmt
+          names: ["array"]
+          value:
+            ArrayLiteral
+              elements:
+                NumberLiteral
+                  value: "1"
+                NumberLiteral
+                  value: "2"
+                NumberLiteral
+                  value: "3"

--- a/bazaar-parser/src/jvmTest/resources/testdata/assigns.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/assigns.bzr
@@ -1,0 +1,15 @@
+package assigns
+
+func Assigns() {
+    var answer = 42
+    var answer = 42.0
+    var answer = "42"
+    var answer int = 42
+    var answer = { return 42 }
+
+    answer += 0
+    answer -= 0
+    answer %= 128
+    answer /= 1
+    answer *= 1
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/assigns.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/assigns.bzr.ast.golden
@@ -1,0 +1,72 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["assigns"]
+  declarations:
+    FunctionDecl
+      name: "Assigns"
+      body:
+        VarDeclStmt
+          names: ["answer"]
+          value:
+            NumberLiteral
+              value: "42"
+        VarDeclStmt
+          names: ["answer"]
+          value:
+            NumberLiteral
+              value: "42.0"
+        VarDeclStmt
+          names: ["answer"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "42"
+        VarDeclStmt
+          names: ["answer"]
+          type:
+            ValueType
+              name: "int"
+          value:
+            NumberLiteral
+              value: "42"
+        VarDeclStmt
+          names: ["answer"]
+          value:
+            LambdaExpr
+              body:
+                ReturnStmt
+                  value:
+                    NumberLiteral
+                      value: "42"
+        AssignStmt
+          target: "answer"
+          op: ADD_ASSIGN
+          value:
+            NumberLiteral
+              value: "0"
+        AssignStmt
+          target: "answer"
+          op: SUB_ASSIGN
+          value:
+            NumberLiteral
+              value: "0"
+        AssignStmt
+          target: "answer"
+          op: MOD_ASSIGN
+          value:
+            NumberLiteral
+              value: "128"
+        AssignStmt
+          target: "answer"
+          op: DIV_ASSIGN
+          value:
+            NumberLiteral
+              value: "1"
+        AssignStmt
+          target: "answer"
+          op: MUL_ASSIGN
+          value:
+            NumberLiteral
+              value: "1"

--- a/bazaar-parser/src/jvmTest/resources/testdata/builtins.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/builtins.bzr
@@ -1,0 +1,19 @@
+package builtins
+
+func BuiltinFunctions(list [string], items [int]) {
+    for i in range(0, 10) {}
+    for (idx, val) in enumerate(list) {}
+    var size = len(items)
+
+    if len(items) > 0 {}
+    for i in range(0, len(list)) {}
+
+    var rangeVar = range(1, 5)
+    var enumerateVar = enumerate(items)
+    var lengthCheck = len(list) + len(items)
+
+    for (i, item) in enumerate(range(0, len(list))) {}
+
+    for entry in enumerate(list) {}
+    var complexRange = range(len(items), len(items) + 10)
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/builtins.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/builtins.bzr.ast.golden
@@ -1,0 +1,236 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["builtins"]
+  declarations:
+    FunctionDecl
+      name: "BuiltinFunctions"
+      params:
+        ParameterDecl
+          name: "list"
+          type:
+            ArrayType
+              elementType:
+                ValueType
+                  name: "string"
+        ParameterDecl
+          name: "items"
+          type:
+            ArrayType
+              elementType:
+                ValueType
+                  name: "int"
+      body:
+        ForInStmt
+          names: ["i"]
+          iterable:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "range"
+              args:
+                Argument
+                  value:
+                    NumberLiteral
+                      value: "0"
+                Argument
+                  value:
+                    NumberLiteral
+                      value: "10"
+        ForInStmt
+          names: ["idx", "val"]
+          iterable:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "enumerate"
+              args:
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "list"
+        VarDeclStmt
+          names: ["size"]
+          value:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "len"
+              args:
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "items"
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: GT
+                  left:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "len"
+                      args:
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "items"
+                  right:
+                    NumberLiteral
+                      value: "0"
+        ForInStmt
+          names: ["i"]
+          iterable:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "range"
+              args:
+                Argument
+                  value:
+                    NumberLiteral
+                      value: "0"
+                Argument
+                  value:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "len"
+                      args:
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "list"
+        VarDeclStmt
+          names: ["rangeVar"]
+          value:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "range"
+              args:
+                Argument
+                  value:
+                    NumberLiteral
+                      value: "1"
+                Argument
+                  value:
+                    NumberLiteral
+                      value: "5"
+        VarDeclStmt
+          names: ["enumerateVar"]
+          value:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "enumerate"
+              args:
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "items"
+        VarDeclStmt
+          names: ["lengthCheck"]
+          value:
+            BinaryExpr
+              op: ADD
+              left:
+                CallExpr
+                  target:
+                    ReferenceExpr
+                      name: "len"
+                  args:
+                    Argument
+                      value:
+                        ReferenceExpr
+                          name: "list"
+              right:
+                CallExpr
+                  target:
+                    ReferenceExpr
+                      name: "len"
+                  args:
+                    Argument
+                      value:
+                        ReferenceExpr
+                          name: "items"
+        ForInStmt
+          names: ["i", "item"]
+          iterable:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "enumerate"
+              args:
+                Argument
+                  value:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "range"
+                      args:
+                        Argument
+                          value:
+                            NumberLiteral
+                              value: "0"
+                        Argument
+                          value:
+                            CallExpr
+                              target:
+                                ReferenceExpr
+                                  name: "len"
+                              args:
+                                Argument
+                                  value:
+                                    ReferenceExpr
+                                      name: "list"
+        ForInStmt
+          names: ["entry"]
+          iterable:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "enumerate"
+              args:
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "list"
+        VarDeclStmt
+          names: ["complexRange"]
+          value:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "range"
+              args:
+                Argument
+                  value:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "len"
+                      args:
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "items"
+                Argument
+                  value:
+                    BinaryExpr
+                      op: ADD
+                      left:
+                        CallExpr
+                          target:
+                            ReferenceExpr
+                              name: "len"
+                          args:
+                            Argument
+                              value:
+                                ReferenceExpr
+                                  name: "items"
+                      right:
+                        NumberLiteral
+                          value: "10"

--- a/bazaar-parser/src/jvmTest/resources/testdata/calls.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/calls.bzr
@@ -1,0 +1,14 @@
+package calls
+
+func Calls() {
+    Print("Hello, world!")
+    BlockLiteral({})
+    NamedArgs(first = 1337, second = "second")
+    TrailingBlockLiteral {}
+
+    // Complex trailing commas from edge-cases.bzr
+    call(
+        first,
+        second,
+    )
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/calls.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/calls.bzr.ast.golden
@@ -1,0 +1,73 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["calls"]
+  declarations:
+    FunctionDecl
+      name: "Calls"
+      body:
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "Print"
+              args:
+                Argument
+                  value:
+                    StringLiteral
+                      parts:
+                        TextPart
+                          text: "Hello, world!"
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "BlockLiteral"
+              args:
+                Argument
+                  value:
+                    LambdaExpr
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "NamedArgs"
+              args:
+                Argument
+                  name: "first"
+                  value:
+                    NumberLiteral
+                      value: "1337"
+                Argument
+                  name: "second"
+                  value:
+                    StringLiteral
+                      parts:
+                        TextPart
+                          text: "second"
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "TrailingBlockLiteral"
+              trailingLambda:
+                LambdaExpr
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "call"
+              args:
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "first"
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "second"

--- a/bazaar-parser/src/jvmTest/resources/testdata/edge-cases.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/edge-cases.bzr
@@ -1,0 +1,28 @@
+package edgecases
+
+enum EmptyEnum {}
+
+enum TrailingCommaEnum {
+    a, b, c,
+}
+
+component EmptyComponent {}
+
+data EmptyData {}
+
+template EmptyTemplate {}
+
+func EdgeCases() {
+    var component = "foo"
+    var data = "bar"
+    var modifier = "baz"
+    var package = "qux"
+    var len = "foo"
+    var enumerate = "bar"
+    var range = "baz"
+
+    // Trailing comma tests
+    var arrayWithTrailing = [1, 2, 3,]
+    var mapWithTrailing = {a: 1, b: 2,}
+    for (a, b,) in something {}
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/edge-cases.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/edge-cases.bzr.ast.golden
@@ -1,0 +1,103 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["edgecases"]
+  declarations:
+    EnumDecl
+      name: "EmptyEnum"
+    EnumDecl
+      name: "TrailingCommaEnum"
+      values: ["a", "b", "c"]
+    ComponentDecl
+      name: "EmptyComponent"
+    DataDecl
+      name: "EmptyData"
+    TemplateDecl
+      name: "EmptyTemplate"
+    FunctionDecl
+      name: "EdgeCases"
+      body:
+        VarDeclStmt
+          names: ["component"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "foo"
+        VarDeclStmt
+          names: ["data"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "bar"
+        VarDeclStmt
+          names: ["modifier"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "baz"
+        VarDeclStmt
+          names: ["package"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "qux"
+        VarDeclStmt
+          names: ["len"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "foo"
+        VarDeclStmt
+          names: ["enumerate"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "bar"
+        VarDeclStmt
+          names: ["range"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "baz"
+        VarDeclStmt
+          names: ["arrayWithTrailing"]
+          value:
+            ArrayLiteral
+              elements:
+                NumberLiteral
+                  value: "1"
+                NumberLiteral
+                  value: "2"
+                NumberLiteral
+                  value: "3"
+        VarDeclStmt
+          names: ["mapWithTrailing"]
+          value:
+            MapLiteral
+              entries:
+                MapEntry
+                  key:
+                    ReferenceExpr
+                      name: "a"
+                  value:
+                    NumberLiteral
+                      value: "1"
+                MapEntry
+                  key:
+                    ReferenceExpr
+                      name: "b"
+                  value:
+                    NumberLiteral
+                      value: "2"
+        ForInStmt
+          names: ["a", "b"]
+          iterable:
+            ReferenceExpr
+              name: "something"

--- a/bazaar-parser/src/jvmTest/resources/testdata/example.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/example.bzr
@@ -1,0 +1,71 @@
+package example
+
+import layout
+
+enum RowAlignment {
+    top, center, bottom
+}
+
+component Row {
+    alignment RowAlignment = RowAlignment.center
+    children [component]
+}
+
+component Button {
+    label string
+    onClick func()? = null
+}
+
+component Text {
+    value string
+}
+
+modifier Padding {
+    top double = 0
+    leading double = 0
+    bottom double = 0
+    trailing double = 0
+
+    constructor(all double) = Padding(all, all, all, all)
+    constructor(vertical double, horizontal double) = Padding(vertical, horizontal, vertical, horizontal)
+}
+
+func Add(x int, y int) -> int
+
+func Truncate(x double) -> int
+
+func Print(message string)
+
+func Dismiss(animated bool = false)
+
+data Point {
+    x double = 0.0
+    y double = 0
+}
+
+data TextAndButtonRowModel {
+    value string = "Hello, world!"
+    label string = "Click, me!"
+    message string? = null
+}
+
+template TextAndButtonRow(models [TextAndButtonRowModel]) {
+    @State var count = 0
+
+    for model in models {
+        @Modifier(Padding(all = 12.0))
+        Row {
+            Text(model.value)
+            Button(model.label) {
+                count += 1
+                if var message = model.message {
+                    Print(message)
+                }
+            }
+        }
+    }
+}
+
+preview TextAndButtonRowPreview {
+    TextAndButtonRow([TextAndButtonRowModel()])
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/example.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/example.bzr.ast.golden
@@ -1,0 +1,376 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["example"]
+  imports:
+    ImportDecl
+      segments: ["layout"]
+  declarations:
+    EnumDecl
+      name: "RowAlignment"
+      values: ["top", "center", "bottom"]
+    ComponentDecl
+      name: "Row"
+      members:
+        FieldDecl
+          name: "alignment"
+          type:
+            ValueType
+              name: "RowAlignment"
+          default:
+            MemberExpr
+              target:
+                ReferenceExpr
+                  name: "RowAlignment"
+              member: "center"
+        FieldDecl
+          name: "children"
+          type:
+            ArrayType
+              elementType:
+                ValueType
+                  name: "component"
+    ComponentDecl
+      name: "Button"
+      members:
+        FieldDecl
+          name: "label"
+          type:
+            ValueType
+              name: "string"
+        FieldDecl
+          name: "onClick"
+          type:
+            FunctionType
+              nullable: true
+          default:
+            NullLiteral
+    ComponentDecl
+      name: "Text"
+      members:
+        FieldDecl
+          name: "value"
+          type:
+            ValueType
+              name: "string"
+    ModifierDecl
+      name: "Padding"
+      members:
+        FieldDecl
+          name: "top"
+          type:
+            ValueType
+              name: "double"
+          default:
+            NumberLiteral
+              value: "0"
+        FieldDecl
+          name: "leading"
+          type:
+            ValueType
+              name: "double"
+          default:
+            NumberLiteral
+              value: "0"
+        FieldDecl
+          name: "bottom"
+          type:
+            ValueType
+              name: "double"
+          default:
+            NumberLiteral
+              value: "0"
+        FieldDecl
+          name: "trailing"
+          type:
+            ValueType
+              name: "double"
+          default:
+            NumberLiteral
+              value: "0"
+        ConstructorDecl
+          params:
+            ParameterDecl
+              name: "all"
+              type:
+                ValueType
+                  name: "double"
+          value:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "Padding"
+              args:
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "all"
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "all"
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "all"
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "all"
+        ConstructorDecl
+          params:
+            ParameterDecl
+              name: "vertical"
+              type:
+                ValueType
+                  name: "double"
+            ParameterDecl
+              name: "horizontal"
+              type:
+                ValueType
+                  name: "double"
+          value:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "Padding"
+              args:
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "vertical"
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "horizontal"
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "vertical"
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "horizontal"
+    FunctionDecl
+      name: "Add"
+      params:
+        ParameterDecl
+          name: "x"
+          type:
+            ValueType
+              name: "int"
+        ParameterDecl
+          name: "y"
+          type:
+            ValueType
+              name: "int"
+      returnType:
+        ValueType
+          name: "int"
+    FunctionDecl
+      name: "Truncate"
+      params:
+        ParameterDecl
+          name: "x"
+          type:
+            ValueType
+              name: "double"
+      returnType:
+        ValueType
+          name: "int"
+    FunctionDecl
+      name: "Print"
+      params:
+        ParameterDecl
+          name: "message"
+          type:
+            ValueType
+              name: "string"
+    FunctionDecl
+      name: "Dismiss"
+      params:
+        ParameterDecl
+          name: "animated"
+          type:
+            ValueType
+              name: "bool"
+          default:
+            BoolLiteral
+              value: false
+    DataDecl
+      name: "Point"
+      members:
+        FieldDecl
+          name: "x"
+          type:
+            ValueType
+              name: "double"
+          default:
+            NumberLiteral
+              value: "0.0"
+        FieldDecl
+          name: "y"
+          type:
+            ValueType
+              name: "double"
+          default:
+            NumberLiteral
+              value: "0"
+    DataDecl
+      name: "TextAndButtonRowModel"
+      members:
+        FieldDecl
+          name: "value"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Hello, world!"
+        FieldDecl
+          name: "label"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Click, me!"
+        FieldDecl
+          name: "message"
+          type:
+            ValueType
+              name: "string"
+              nullable: true
+          default:
+            NullLiteral
+    TemplateDecl
+      name: "TextAndButtonRow"
+      params:
+        ParameterDecl
+          name: "models"
+          type:
+            ArrayType
+              elementType:
+                ValueType
+                  name: "TextAndButtonRowModel"
+      body:
+        VarDeclStmt
+          names: ["count"]
+          value:
+            NumberLiteral
+              value: "0"
+          annotations:
+            Annotation
+              name: "State"
+        ForInStmt
+          names: ["model"]
+          iterable:
+            ReferenceExpr
+              name: "models"
+          body:
+            CallStmt
+              annotations:
+                Annotation
+                  name: "Modifier"
+                  args:
+                    Argument
+                      value:
+                        CallExpr
+                          target:
+                            ReferenceExpr
+                              name: "Padding"
+                          args:
+                            Argument
+                              name: "all"
+                              value:
+                                NumberLiteral
+                                  value: "12.0"
+              expr:
+                CallExpr
+                  target:
+                    ReferenceExpr
+                      name: "Row"
+                  trailingLambda:
+                    LambdaExpr
+                      body:
+                        ExprStmt
+                          expr:
+                            CallExpr
+                              target:
+                                ReferenceExpr
+                                  name: "Text"
+                              args:
+                                Argument
+                                  value:
+                                    MemberExpr
+                                      target:
+                                        ReferenceExpr
+                                          name: "model"
+                                      member: "value"
+                        ExprStmt
+                          expr:
+                            CallExpr
+                              target:
+                                ReferenceExpr
+                                  name: "Button"
+                              args:
+                                Argument
+                                  value:
+                                    MemberExpr
+                                      target:
+                                        ReferenceExpr
+                                          name: "model"
+                                      member: "label"
+                              trailingLambda:
+                                LambdaExpr
+                                  body:
+                                    AssignStmt
+                                      target: "count"
+                                      op: ADD_ASSIGN
+                                      value:
+                                        NumberLiteral
+                                          value: "1"
+                                    IfStmt
+                                      fragments:
+                                        IfVarFragment
+                                          names: ["message"]
+                                          value:
+                                            MemberExpr
+                                              target:
+                                                ReferenceExpr
+                                                  name: "model"
+                                              member: "message"
+                                      body:
+                                        ExprStmt
+                                          expr:
+                                            CallExpr
+                                              target:
+                                                ReferenceExpr
+                                                  name: "Print"
+                                              args:
+                                                Argument
+                                                  value:
+                                                    ReferenceExpr
+                                                      name: "message"
+    PreviewDecl
+      name: "TextAndButtonRowPreview"
+      body:
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "TextAndButtonRow"
+              args:
+                Argument
+                  value:
+                    ArrayLiteral
+                      elements:
+                        CallExpr
+                          target:
+                            ReferenceExpr
+                              name: "TextAndButtonRowModel"

--- a/bazaar-parser/src/jvmTest/resources/testdata/fors.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/fors.bzr
@@ -1,0 +1,13 @@
+package fors
+
+func Fors(list [string], map {string: int}) {
+    for value in list {}
+    for entry in map {}
+    for entry in enumerate(map) {}
+    for idx in range(0, 10) {}
+    for (idx, value) in enumerate(list) {}
+    for (key, value) in enumerate(map) {}
+
+    var idx = 0
+    for idx < len(list) { idx += 1 }
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/fors.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/fors.bzr.ast.golden
@@ -1,0 +1,117 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["fors"]
+  declarations:
+    FunctionDecl
+      name: "Fors"
+      params:
+        ParameterDecl
+          name: "list"
+          type:
+            ArrayType
+              elementType:
+                ValueType
+                  name: "string"
+        ParameterDecl
+          name: "map"
+          type:
+            MapType
+              keyType:
+                ValueType
+                  name: "string"
+              valueType:
+                ValueType
+                  name: "int"
+      body:
+        ForInStmt
+          names: ["value"]
+          iterable:
+            ReferenceExpr
+              name: "list"
+        ForInStmt
+          names: ["entry"]
+          iterable:
+            ReferenceExpr
+              name: "map"
+        ForInStmt
+          names: ["entry"]
+          iterable:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "enumerate"
+              args:
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "map"
+        ForInStmt
+          names: ["idx"]
+          iterable:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "range"
+              args:
+                Argument
+                  value:
+                    NumberLiteral
+                      value: "0"
+                Argument
+                  value:
+                    NumberLiteral
+                      value: "10"
+        ForInStmt
+          names: ["idx", "value"]
+          iterable:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "enumerate"
+              args:
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "list"
+        ForInStmt
+          names: ["key", "value"]
+          iterable:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "enumerate"
+              args:
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "map"
+        VarDeclStmt
+          names: ["idx"]
+          value:
+            NumberLiteral
+              value: "0"
+        ForCondStmt
+          condition:
+            BinaryExpr
+              op: LT
+              left:
+                ReferenceExpr
+                  name: "idx"
+              right:
+                CallExpr
+                  target:
+                    ReferenceExpr
+                      name: "len"
+                  args:
+                    Argument
+                      value:
+                        ReferenceExpr
+                          name: "list"
+          body:
+            AssignStmt
+              target: "idx"
+              op: ADD_ASSIGN
+              value:
+                NumberLiteral
+                  value: "1"

--- a/bazaar-parser/src/jvmTest/resources/testdata/functions.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/functions.bzr
@@ -1,0 +1,16 @@
+package functions
+
+data FunctionFields {
+    empty func()
+    add func(int, int) -> int
+    trailingComma func(int,)
+    optional func()?
+    nestedOptional (func() -> string?)?
+    extraNested ((func()?))
+}
+
+func DefinedBody() -> int {
+    return 42
+}
+
+func HigherOrderFunction() -> func() -> func()

--- a/bazaar-parser/src/jvmTest/resources/testdata/functions.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/functions.bzr.ast.golden
@@ -1,0 +1,66 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["functions"]
+  declarations:
+    DataDecl
+      name: "FunctionFields"
+      members:
+        FieldDecl
+          name: "empty"
+          type:
+            FunctionType
+        FieldDecl
+          name: "add"
+          type:
+            FunctionType
+              paramTypes:
+                ValueType
+                  name: "int"
+                ValueType
+                  name: "int"
+              returnType:
+                ValueType
+                  name: "int"
+        FieldDecl
+          name: "trailingComma"
+          type:
+            FunctionType
+              paramTypes:
+                ValueType
+                  name: "int"
+        FieldDecl
+          name: "optional"
+          type:
+            FunctionType
+              nullable: true
+        FieldDecl
+          name: "nestedOptional"
+          type:
+            FunctionType
+              returnType:
+                ValueType
+                  name: "string"
+                  nullable: true
+              nullable: true
+        FieldDecl
+          name: "extraNested"
+          type:
+            FunctionType
+              nullable: true
+    FunctionDecl
+      name: "DefinedBody"
+      returnType:
+        ValueType
+          name: "int"
+      body:
+        ReturnStmt
+          value:
+            NumberLiteral
+              value: "42"
+    FunctionDecl
+      name: "HigherOrderFunction"
+      returnType:
+        FunctionType
+          returnType:
+            FunctionType

--- a/bazaar-parser/src/jvmTest/resources/testdata/ifs.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/ifs.bzr
@@ -1,0 +1,35 @@
+package ifs
+
+func Ifs(foo bool, bar bool, baz bool?) {
+    if foo != bar {}
+    if foo == bar {}
+    if foo == bar && foo != true {}
+    if (foo == bar || (foo != true)) {}
+    if true || (!(false) && true) {}
+    if (foo && bar) || (baz == true) {}
+    if var baz, baz == bar {}
+    if var baz = baz, foo == bar == baz {}
+    if var (bar, baz) = foo {}
+    if 10 > len(something) {}
+
+    // Simple if/else
+    if true {} else {}
+    if foo == bar {} else {}
+
+    // if/else if chains
+    if foo == 1 {} else if foo == 2 {}
+    if foo == 1 {} else if foo == 2 {} else if foo == 3 {}
+
+    // if/else if/else combinations
+    if true {} else if false {} else {}
+    if foo == bar {} else if bar == baz {} else {}
+    if foo == 1 {} else if foo == 2 {} else if foo == 3 {} else {}
+
+    // Complex conditions in else if clauses
+    if foo && bar {} else if (foo || bar) && baz {} else {}
+    if var x = getValue(), x > 0 {} else if var y = getOther(), y < 0 {} else {}
+
+    // Variable declarations in else if fragments
+    if var a {} else if var b = something {} else {}
+    if var (x, y) = coords {} else if var z = fallback {} else {}
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/ifs.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/ifs.bzr.ast.golden
@@ -1,0 +1,457 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["ifs"]
+  declarations:
+    FunctionDecl
+      name: "Ifs"
+      params:
+        ParameterDecl
+          name: "foo"
+          type:
+            ValueType
+              name: "bool"
+        ParameterDecl
+          name: "bar"
+          type:
+            ValueType
+              name: "bool"
+        ParameterDecl
+          name: "baz"
+          type:
+            ValueType
+              name: "bool"
+              nullable: true
+      body:
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: NEQ
+                  left:
+                    ReferenceExpr
+                      name: "foo"
+                  right:
+                    ReferenceExpr
+                      name: "bar"
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: EQ
+                  left:
+                    ReferenceExpr
+                      name: "foo"
+                  right:
+                    ReferenceExpr
+                      name: "bar"
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: AND
+                  left:
+                    BinaryExpr
+                      op: EQ
+                      left:
+                        ReferenceExpr
+                          name: "foo"
+                      right:
+                        ReferenceExpr
+                          name: "bar"
+                  right:
+                    BinaryExpr
+                      op: NEQ
+                      left:
+                        ReferenceExpr
+                          name: "foo"
+                      right:
+                        BoolLiteral
+                          value: true
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: OR
+                  left:
+                    BinaryExpr
+                      op: EQ
+                      left:
+                        ReferenceExpr
+                          name: "foo"
+                      right:
+                        ReferenceExpr
+                          name: "bar"
+                  right:
+                    BinaryExpr
+                      op: NEQ
+                      left:
+                        ReferenceExpr
+                          name: "foo"
+                      right:
+                        BoolLiteral
+                          value: true
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: OR
+                  left:
+                    BoolLiteral
+                      value: true
+                  right:
+                    BinaryExpr
+                      op: AND
+                      left:
+                        UnaryExpr
+                          op: NOT
+                          operand:
+                            BoolLiteral
+                              value: false
+                      right:
+                        BoolLiteral
+                          value: true
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: OR
+                  left:
+                    BinaryExpr
+                      op: AND
+                      left:
+                        ReferenceExpr
+                          name: "foo"
+                      right:
+                        ReferenceExpr
+                          name: "bar"
+                  right:
+                    BinaryExpr
+                      op: EQ
+                      left:
+                        ReferenceExpr
+                          name: "baz"
+                      right:
+                        BoolLiteral
+                          value: true
+        IfStmt
+          fragments:
+            IfVarFragment
+              names: ["baz"]
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: EQ
+                  left:
+                    ReferenceExpr
+                      name: "baz"
+                  right:
+                    ReferenceExpr
+                      name: "bar"
+        IfStmt
+          fragments:
+            IfVarFragment
+              names: ["baz"]
+              value:
+                ReferenceExpr
+                  name: "baz"
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: EQ
+                  left:
+                    BinaryExpr
+                      op: EQ
+                      left:
+                        ReferenceExpr
+                          name: "foo"
+                      right:
+                        ReferenceExpr
+                          name: "bar"
+                  right:
+                    ReferenceExpr
+                      name: "baz"
+        IfStmt
+          fragments:
+            IfVarFragment
+              names: ["bar", "baz"]
+              value:
+                ReferenceExpr
+                  name: "foo"
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: GT
+                  left:
+                    NumberLiteral
+                      value: "10"
+                  right:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "len"
+                      args:
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "something"
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BoolLiteral
+                  value: true
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: EQ
+                  left:
+                    ReferenceExpr
+                      name: "foo"
+                  right:
+                    ReferenceExpr
+                      name: "bar"
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: EQ
+                  left:
+                    ReferenceExpr
+                      name: "foo"
+                  right:
+                    NumberLiteral
+                      value: "1"
+          elseIfs:
+            ElseIf
+              fragments:
+                IfExprFragment
+                  expr:
+                    BinaryExpr
+                      op: EQ
+                      left:
+                        ReferenceExpr
+                          name: "foo"
+                      right:
+                        NumberLiteral
+                          value: "2"
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: EQ
+                  left:
+                    ReferenceExpr
+                      name: "foo"
+                  right:
+                    NumberLiteral
+                      value: "1"
+          elseIfs:
+            ElseIf
+              fragments:
+                IfExprFragment
+                  expr:
+                    BinaryExpr
+                      op: EQ
+                      left:
+                        ReferenceExpr
+                          name: "foo"
+                      right:
+                        NumberLiteral
+                          value: "2"
+            ElseIf
+              fragments:
+                IfExprFragment
+                  expr:
+                    BinaryExpr
+                      op: EQ
+                      left:
+                        ReferenceExpr
+                          name: "foo"
+                      right:
+                        NumberLiteral
+                          value: "3"
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BoolLiteral
+                  value: true
+          elseIfs:
+            ElseIf
+              fragments:
+                IfExprFragment
+                  expr:
+                    BoolLiteral
+                      value: false
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: EQ
+                  left:
+                    ReferenceExpr
+                      name: "foo"
+                  right:
+                    ReferenceExpr
+                      name: "bar"
+          elseIfs:
+            ElseIf
+              fragments:
+                IfExprFragment
+                  expr:
+                    BinaryExpr
+                      op: EQ
+                      left:
+                        ReferenceExpr
+                          name: "bar"
+                      right:
+                        ReferenceExpr
+                          name: "baz"
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: EQ
+                  left:
+                    ReferenceExpr
+                      name: "foo"
+                  right:
+                    NumberLiteral
+                      value: "1"
+          elseIfs:
+            ElseIf
+              fragments:
+                IfExprFragment
+                  expr:
+                    BinaryExpr
+                      op: EQ
+                      left:
+                        ReferenceExpr
+                          name: "foo"
+                      right:
+                        NumberLiteral
+                          value: "2"
+            ElseIf
+              fragments:
+                IfExprFragment
+                  expr:
+                    BinaryExpr
+                      op: EQ
+                      left:
+                        ReferenceExpr
+                          name: "foo"
+                      right:
+                        NumberLiteral
+                          value: "3"
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: AND
+                  left:
+                    ReferenceExpr
+                      name: "foo"
+                  right:
+                    ReferenceExpr
+                      name: "bar"
+          elseIfs:
+            ElseIf
+              fragments:
+                IfExprFragment
+                  expr:
+                    BinaryExpr
+                      op: AND
+                      left:
+                        BinaryExpr
+                          op: OR
+                          left:
+                            ReferenceExpr
+                              name: "foo"
+                          right:
+                            ReferenceExpr
+                              name: "bar"
+                      right:
+                        ReferenceExpr
+                          name: "baz"
+        IfStmt
+          fragments:
+            IfVarFragment
+              names: ["x"]
+              value:
+                CallExpr
+                  target:
+                    ReferenceExpr
+                      name: "getValue"
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: GT
+                  left:
+                    ReferenceExpr
+                      name: "x"
+                  right:
+                    NumberLiteral
+                      value: "0"
+          elseIfs:
+            ElseIf
+              fragments:
+                IfVarFragment
+                  names: ["y"]
+                  value:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "getOther"
+                IfExprFragment
+                  expr:
+                    BinaryExpr
+                      op: LT
+                      left:
+                        ReferenceExpr
+                          name: "y"
+                      right:
+                        NumberLiteral
+                          value: "0"
+        IfStmt
+          fragments:
+            IfVarFragment
+              names: ["a"]
+          elseIfs:
+            ElseIf
+              fragments:
+                IfVarFragment
+                  names: ["b"]
+                  value:
+                    ReferenceExpr
+                      name: "something"
+        IfStmt
+          fragments:
+            IfVarFragment
+              names: ["x", "y"]
+              value:
+                ReferenceExpr
+                  name: "coords"
+          elseIfs:
+            ElseIf
+              fragments:
+                IfVarFragment
+                  names: ["z"]
+                  value:
+                    ReferenceExpr
+                      name: "fallback"

--- a/bazaar-parser/src/jvmTest/resources/testdata/imports.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/imports.bzr
@@ -1,0 +1,11 @@
+package imports
+
+import foo.bar.baz
+import foo.bar.baz.Qux
+
+// Import aliases
+import bar.baz.Qux as Foo
+import very.long.path.Component as Brief
+import SomeComponent as Short
+import ui.components.Button as Btn
+import data.models.User as UserModel

--- a/bazaar-parser/src/jvmTest/resources/testdata/imports.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/imports.bzr.ast.golden
@@ -1,0 +1,26 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["imports"]
+  imports:
+    ImportDecl
+      segments: ["foo", "bar", "baz"]
+    ImportDecl
+      segments: ["foo", "bar", "baz", "Qux"]
+    ImportDecl
+      segments: ["bar", "baz", "Qux"]
+      alias: "Foo"
+    ImportDecl
+      segments: ["very", "long", "path", "Component"]
+      alias: "Brief"
+    ImportDecl
+      segments: ["SomeComponent"]
+      alias: "Short"
+    ImportDecl
+      segments: ["ui", "components", "Button"]
+      alias: "Btn"
+    ImportDecl
+      segments: ["<missing IDENTIFIER>"]
+  declarations:
+    DataDecl
+      name: "models"

--- a/bazaar-parser/src/jvmTest/resources/testdata/lambdas.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/lambdas.bzr
@@ -1,0 +1,30 @@
+package lambdas
+
+func Lambdas() {
+    Foo {}
+    Foo { Bar() }
+    Foo { Bar() { Baz {} } }
+    Foo() {}
+    Foo() { Bar() }
+    Foo() { Bar() { Baz() {} } }
+    Foo(bar) { (bar) in Bar() }
+    Foo(bar) { (bar) -> int in Bar() }
+    Foo(bar) { (bar string) -> int in Bar(bar) }
+    Foo(bar) { (bar string, baz string) -> int in Bar(bar) { Baz(baz) } }
+    Foo(bar = { Bar() } ) {
+        Baz()
+    }
+
+    var foo = { (bar) -> int in return bar }
+    var foo = { (bar int) -> int in return bar }
+    var foo = {}
+
+    // Complex lambda parameters from edge-cases.bzr
+    call { (x int, y string) -> bool in
+        return x > 0
+    }
+
+    call { (a, b, c) in
+        return a
+    }
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/lambdas.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/lambdas.bzr.ast.golden
@@ -1,0 +1,359 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["lambdas"]
+  declarations:
+    FunctionDecl
+      name: "Lambdas"
+      body:
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "Foo"
+              trailingLambda:
+                LambdaExpr
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "Foo"
+              trailingLambda:
+                LambdaExpr
+                  body:
+                    ExprStmt
+                      expr:
+                        CallExpr
+                          target:
+                            ReferenceExpr
+                              name: "Bar"
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "Foo"
+              trailingLambda:
+                LambdaExpr
+                  body:
+                    ExprStmt
+                      expr:
+                        CallExpr
+                          target:
+                            ReferenceExpr
+                              name: "Bar"
+                          trailingLambda:
+                            LambdaExpr
+                              body:
+                                ExprStmt
+                                  expr:
+                                    CallExpr
+                                      target:
+                                        ReferenceExpr
+                                          name: "Baz"
+                                      trailingLambda:
+                                        LambdaExpr
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "Foo"
+              trailingLambda:
+                LambdaExpr
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "Foo"
+              trailingLambda:
+                LambdaExpr
+                  body:
+                    ExprStmt
+                      expr:
+                        CallExpr
+                          target:
+                            ReferenceExpr
+                              name: "Bar"
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "Foo"
+              trailingLambda:
+                LambdaExpr
+                  body:
+                    ExprStmt
+                      expr:
+                        CallExpr
+                          target:
+                            ReferenceExpr
+                              name: "Bar"
+                          trailingLambda:
+                            LambdaExpr
+                              body:
+                                ExprStmt
+                                  expr:
+                                    CallExpr
+                                      target:
+                                        ReferenceExpr
+                                          name: "Baz"
+                                      trailingLambda:
+                                        LambdaExpr
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "Foo"
+              args:
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "bar"
+              trailingLambda:
+                LambdaExpr
+                  params:
+                    LambdaParam
+                      name: "bar"
+                  body:
+                    ExprStmt
+                      expr:
+                        CallExpr
+                          target:
+                            ReferenceExpr
+                              name: "Bar"
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "Foo"
+              args:
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "bar"
+              trailingLambda:
+                LambdaExpr
+                  params:
+                    LambdaParam
+                      name: "bar"
+                  returnType:
+                    ValueType
+                      name: "int"
+                  body:
+                    ExprStmt
+                      expr:
+                        CallExpr
+                          target:
+                            ReferenceExpr
+                              name: "Bar"
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "Foo"
+              args:
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "bar"
+              trailingLambda:
+                LambdaExpr
+                  params:
+                    LambdaParam
+                      name: "bar"
+                      type:
+                        ValueType
+                          name: "string"
+                  returnType:
+                    ValueType
+                      name: "int"
+                  body:
+                    ExprStmt
+                      expr:
+                        CallExpr
+                          target:
+                            ReferenceExpr
+                              name: "Bar"
+                          args:
+                            Argument
+                              value:
+                                ReferenceExpr
+                                  name: "bar"
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "Foo"
+              args:
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "bar"
+              trailingLambda:
+                LambdaExpr
+                  params:
+                    LambdaParam
+                      name: "bar"
+                      type:
+                        ValueType
+                          name: "string"
+                    LambdaParam
+                      name: "baz"
+                      type:
+                        ValueType
+                          name: "string"
+                  returnType:
+                    ValueType
+                      name: "int"
+                  body:
+                    ExprStmt
+                      expr:
+                        CallExpr
+                          target:
+                            ReferenceExpr
+                              name: "Bar"
+                          args:
+                            Argument
+                              value:
+                                ReferenceExpr
+                                  name: "bar"
+                          trailingLambda:
+                            LambdaExpr
+                              body:
+                                ExprStmt
+                                  expr:
+                                    CallExpr
+                                      target:
+                                        ReferenceExpr
+                                          name: "Baz"
+                                      args:
+                                        Argument
+                                          value:
+                                            ReferenceExpr
+                                              name: "baz"
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "Foo"
+              args:
+                Argument
+                  name: "bar"
+                  value:
+                    LambdaExpr
+                      body:
+                        ExprStmt
+                          expr:
+                            CallExpr
+                              target:
+                                ReferenceExpr
+                                  name: "Bar"
+              trailingLambda:
+                LambdaExpr
+                  body:
+                    ExprStmt
+                      expr:
+                        CallExpr
+                          target:
+                            ReferenceExpr
+                              name: "Baz"
+        VarDeclStmt
+          names: ["foo"]
+          value:
+            LambdaExpr
+              params:
+                LambdaParam
+                  name: "bar"
+              returnType:
+                ValueType
+                  name: "int"
+              body:
+                ReturnStmt
+                  value:
+                    ReferenceExpr
+                      name: "bar"
+        VarDeclStmt
+          names: ["foo"]
+          value:
+            LambdaExpr
+              params:
+                LambdaParam
+                  name: "bar"
+                  type:
+                    ValueType
+                      name: "int"
+              returnType:
+                ValueType
+                  name: "int"
+              body:
+                ReturnStmt
+                  value:
+                    ReferenceExpr
+                      name: "bar"
+        VarDeclStmt
+          names: ["foo"]
+          value:
+            LambdaExpr
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "call"
+              trailingLambda:
+                LambdaExpr
+                  params:
+                    LambdaParam
+                      name: "x"
+                      type:
+                        ValueType
+                          name: "int"
+                    LambdaParam
+                      name: "y"
+                      type:
+                        ValueType
+                          name: "string"
+                  returnType:
+                    ValueType
+                      name: "bool"
+                  body:
+                    ReturnStmt
+                      value:
+                        BinaryExpr
+                          op: GT
+                          left:
+                            ReferenceExpr
+                              name: "x"
+                          right:
+                            NumberLiteral
+                              value: "0"
+        ExprStmt
+          expr:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "call"
+              trailingLambda:
+                LambdaExpr
+                  params:
+                    LambdaParam
+                      name: "a"
+                    LambdaParam
+                      name: "b"
+                    LambdaParam
+                      name: "c"
+                  body:
+                    ReturnStmt
+                      value:
+                        ReferenceExpr
+                          name: "a"

--- a/bazaar-parser/src/jvmTest/resources/testdata/maps.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/maps.bzr
@@ -1,0 +1,16 @@
+package maps
+
+data MapFields {
+    empty {string: int} = {:}
+    singleValue {string: int} = {"key": 42}
+    trailingComma {string: int} = {"key": 42,}
+    optionalValue {string: int?} = {"key": null}
+    optionalMap {string: int}?
+}
+
+func Maps() {
+    var map = {:}
+    var map = {a: 1}
+    var map = {a: 1, b: 2,}
+    var map = {"a": 1, "b": 2}
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/maps.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/maps.bzr.ast.golden
@@ -1,0 +1,158 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["maps"]
+  declarations:
+    DataDecl
+      name: "MapFields"
+      members:
+        FieldDecl
+          name: "empty"
+          type:
+            MapType
+              keyType:
+                ValueType
+                  name: "string"
+              valueType:
+                ValueType
+                  name: "int"
+          default:
+            MapLiteral
+        FieldDecl
+          name: "singleValue"
+          type:
+            MapType
+              keyType:
+                ValueType
+                  name: "string"
+              valueType:
+                ValueType
+                  name: "int"
+          default:
+            MapLiteral
+              entries:
+                MapEntry
+                  key:
+                    StringLiteral
+                      parts:
+                        TextPart
+                          text: "key"
+                  value:
+                    NumberLiteral
+                      value: "42"
+        FieldDecl
+          name: "trailingComma"
+          type:
+            MapType
+              keyType:
+                ValueType
+                  name: "string"
+              valueType:
+                ValueType
+                  name: "int"
+          default:
+            MapLiteral
+              entries:
+                MapEntry
+                  key:
+                    StringLiteral
+                      parts:
+                        TextPart
+                          text: "key"
+                  value:
+                    NumberLiteral
+                      value: "42"
+        FieldDecl
+          name: "optionalValue"
+          type:
+            MapType
+              keyType:
+                ValueType
+                  name: "string"
+              valueType:
+                ValueType
+                  name: "int"
+                  nullable: true
+          default:
+            MapLiteral
+              entries:
+                MapEntry
+                  key:
+                    StringLiteral
+                      parts:
+                        TextPart
+                          text: "key"
+                  value:
+                    NullLiteral
+        FieldDecl
+          name: "optionalMap"
+          type:
+            MapType
+              keyType:
+                ValueType
+                  name: "string"
+              valueType:
+                ValueType
+                  name: "int"
+              nullable: true
+    FunctionDecl
+      name: "Maps"
+      body:
+        VarDeclStmt
+          names: ["map"]
+          value:
+            MapLiteral
+        VarDeclStmt
+          names: ["map"]
+          value:
+            MapLiteral
+              entries:
+                MapEntry
+                  key:
+                    ReferenceExpr
+                      name: "a"
+                  value:
+                    NumberLiteral
+                      value: "1"
+        VarDeclStmt
+          names: ["map"]
+          value:
+            MapLiteral
+              entries:
+                MapEntry
+                  key:
+                    ReferenceExpr
+                      name: "a"
+                  value:
+                    NumberLiteral
+                      value: "1"
+                MapEntry
+                  key:
+                    ReferenceExpr
+                      name: "b"
+                  value:
+                    NumberLiteral
+                      value: "2"
+        VarDeclStmt
+          names: ["map"]
+          value:
+            MapLiteral
+              entries:
+                MapEntry
+                  key:
+                    StringLiteral
+                      parts:
+                        TextPart
+                          text: "a"
+                  value:
+                    NumberLiteral
+                      value: "1"
+                MapEntry
+                  key:
+                    StringLiteral
+                      parts:
+                        TextPart
+                          text: "b"
+                  value:
+                    NumberLiteral
+                      value: "2"

--- a/bazaar-parser/src/jvmTest/resources/testdata/operators.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/operators.bzr
@@ -1,0 +1,61 @@
+package operators
+
+func Operators() {
+    // Comparison operators (testing <= and >= which are implemented)
+    if x <= y {}
+    if x >= z {}
+    if a <= b && c >= d {}
+
+    // Unary operators
+    var negative = -42
+    var negativeFloat = -3.14
+    var notValue = !true
+    var complexNot = !(x && y)
+
+    // All arithmetic operators together
+    var arithmetic = a + b - c * d / e % f
+
+    // All comparison operators together
+    if a < b && b <= c && c == d && d != e && e >= f && f > g {}
+
+    // Complex operator precedence
+    var grouped = (a + b) * (c - d)
+    var unaryPrecedence = -a + b
+    var precedenceTest = a + b * c - d / e % f
+    var mixedPrecedence = !flag && x < y || z >= w
+
+    // Unary minus with different types
+    var negInt = -123
+    var negFloat = -45.67
+    var negVar = -someValue
+
+    // Logical operators in complex expressions
+    var logicalComplex = (a && b) || (c && d)
+    if !(x || y) && z {}
+
+    // Null coalescing operator
+    var result = value ?? "default"
+    var chained = a ?? b ?? c
+    var complex = (obj?.count ?? 0) + 1
+
+    // Exponentiation operator (highest precedence, right-associative)
+    var power = base ** exponent
+    var rightAssociative = 2 ** 3 ** 2
+    var precedenceTest = 2 + 3 ** 2 * 4
+    var unaryInteraction = -2 ** 2
+    var parentheses = (2 + 3) ** 2
+    var floatingPoint = 2.5 ** 3
+
+    // Scientific notation (lexer-level, not an operator)
+    var scientific = 1.5e10
+    var negative = 2.3e-5
+    var uppercase = 1E3
+    var zeroExponent = 3.14e0
+    var explicitPlus = 1e+5
+
+    // Scientific notation in expressions
+    var mixed = 1e3 + 2e2
+    var complex = 2.5e2 * 3e-1
+    var precedence = 1e2 ** 2
+    var floating = 1.25e-2 / 5e-3
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/operators.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/operators.bzr.ast.golden
@@ -1,0 +1,586 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["operators"]
+  declarations:
+    FunctionDecl
+      name: "Operators"
+      body:
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: LTE
+                  left:
+                    ReferenceExpr
+                      name: "x"
+                  right:
+                    ReferenceExpr
+                      name: "y"
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: GTE
+                  left:
+                    ReferenceExpr
+                      name: "x"
+                  right:
+                    ReferenceExpr
+                      name: "z"
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: AND
+                  left:
+                    BinaryExpr
+                      op: LTE
+                      left:
+                        ReferenceExpr
+                          name: "a"
+                      right:
+                        ReferenceExpr
+                          name: "b"
+                  right:
+                    BinaryExpr
+                      op: GTE
+                      left:
+                        ReferenceExpr
+                          name: "c"
+                      right:
+                        ReferenceExpr
+                          name: "d"
+        VarDeclStmt
+          names: ["negative"]
+          value:
+            UnaryExpr
+              op: NEGATE
+              operand:
+                NumberLiteral
+                  value: "42"
+        VarDeclStmt
+          names: ["negativeFloat"]
+          value:
+            UnaryExpr
+              op: NEGATE
+              operand:
+                NumberLiteral
+                  value: "3.14"
+        VarDeclStmt
+          names: ["notValue"]
+          value:
+            UnaryExpr
+              op: NOT
+              operand:
+                BoolLiteral
+                  value: true
+        VarDeclStmt
+          names: ["complexNot"]
+          value:
+            UnaryExpr
+              op: NOT
+              operand:
+                BinaryExpr
+                  op: AND
+                  left:
+                    ReferenceExpr
+                      name: "x"
+                  right:
+                    ReferenceExpr
+                      name: "y"
+        VarDeclStmt
+          names: ["arithmetic"]
+          value:
+            BinaryExpr
+              op: SUB
+              left:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    ReferenceExpr
+                      name: "a"
+                  right:
+                    ReferenceExpr
+                      name: "b"
+              right:
+                BinaryExpr
+                  op: MOD
+                  left:
+                    BinaryExpr
+                      op: DIV
+                      left:
+                        BinaryExpr
+                          op: MUL
+                          left:
+                            ReferenceExpr
+                              name: "c"
+                          right:
+                            ReferenceExpr
+                              name: "d"
+                      right:
+                        ReferenceExpr
+                          name: "e"
+                  right:
+                    ReferenceExpr
+                      name: "f"
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: AND
+                  left:
+                    BinaryExpr
+                      op: AND
+                      left:
+                        BinaryExpr
+                          op: AND
+                          left:
+                            BinaryExpr
+                              op: AND
+                              left:
+                                BinaryExpr
+                                  op: AND
+                                  left:
+                                    BinaryExpr
+                                      op: LT
+                                      left:
+                                        ReferenceExpr
+                                          name: "a"
+                                      right:
+                                        ReferenceExpr
+                                          name: "b"
+                                  right:
+                                    BinaryExpr
+                                      op: LTE
+                                      left:
+                                        ReferenceExpr
+                                          name: "b"
+                                      right:
+                                        ReferenceExpr
+                                          name: "c"
+                              right:
+                                BinaryExpr
+                                  op: EQ
+                                  left:
+                                    ReferenceExpr
+                                      name: "c"
+                                  right:
+                                    ReferenceExpr
+                                      name: "d"
+                          right:
+                            BinaryExpr
+                              op: NEQ
+                              left:
+                                ReferenceExpr
+                                  name: "d"
+                              right:
+                                ReferenceExpr
+                                  name: "e"
+                      right:
+                        BinaryExpr
+                          op: GTE
+                          left:
+                            ReferenceExpr
+                              name: "e"
+                          right:
+                            ReferenceExpr
+                              name: "f"
+                  right:
+                    BinaryExpr
+                      op: GT
+                      left:
+                        ReferenceExpr
+                          name: "f"
+                      right:
+                        ReferenceExpr
+                          name: "g"
+        VarDeclStmt
+          names: ["grouped"]
+          value:
+            BinaryExpr
+              op: MUL
+              left:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    ReferenceExpr
+                      name: "a"
+                  right:
+                    ReferenceExpr
+                      name: "b"
+              right:
+                BinaryExpr
+                  op: SUB
+                  left:
+                    ReferenceExpr
+                      name: "c"
+                  right:
+                    ReferenceExpr
+                      name: "d"
+        VarDeclStmt
+          names: ["unaryPrecedence"]
+          value:
+            BinaryExpr
+              op: ADD
+              left:
+                UnaryExpr
+                  op: NEGATE
+                  operand:
+                    ReferenceExpr
+                      name: "a"
+              right:
+                ReferenceExpr
+                  name: "b"
+        VarDeclStmt
+          names: ["precedenceTest"]
+          value:
+            BinaryExpr
+              op: SUB
+              left:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    ReferenceExpr
+                      name: "a"
+                  right:
+                    BinaryExpr
+                      op: MUL
+                      left:
+                        ReferenceExpr
+                          name: "b"
+                      right:
+                        ReferenceExpr
+                          name: "c"
+              right:
+                BinaryExpr
+                  op: MOD
+                  left:
+                    BinaryExpr
+                      op: DIV
+                      left:
+                        ReferenceExpr
+                          name: "d"
+                      right:
+                        ReferenceExpr
+                          name: "e"
+                  right:
+                    ReferenceExpr
+                      name: "f"
+        VarDeclStmt
+          names: ["mixedPrecedence"]
+          value:
+            BinaryExpr
+              op: OR
+              left:
+                BinaryExpr
+                  op: AND
+                  left:
+                    UnaryExpr
+                      op: NOT
+                      operand:
+                        ReferenceExpr
+                          name: "flag"
+                  right:
+                    BinaryExpr
+                      op: LT
+                      left:
+                        ReferenceExpr
+                          name: "x"
+                      right:
+                        ReferenceExpr
+                          name: "y"
+              right:
+                BinaryExpr
+                  op: GTE
+                  left:
+                    ReferenceExpr
+                      name: "z"
+                  right:
+                    ReferenceExpr
+                      name: "w"
+        VarDeclStmt
+          names: ["negInt"]
+          value:
+            UnaryExpr
+              op: NEGATE
+              operand:
+                NumberLiteral
+                  value: "123"
+        VarDeclStmt
+          names: ["negFloat"]
+          value:
+            UnaryExpr
+              op: NEGATE
+              operand:
+                NumberLiteral
+                  value: "45.67"
+        VarDeclStmt
+          names: ["negVar"]
+          value:
+            UnaryExpr
+              op: NEGATE
+              operand:
+                ReferenceExpr
+                  name: "someValue"
+        VarDeclStmt
+          names: ["logicalComplex"]
+          value:
+            BinaryExpr
+              op: OR
+              left:
+                BinaryExpr
+                  op: AND
+                  left:
+                    ReferenceExpr
+                      name: "a"
+                  right:
+                    ReferenceExpr
+                      name: "b"
+              right:
+                BinaryExpr
+                  op: AND
+                  left:
+                    ReferenceExpr
+                      name: "c"
+                  right:
+                    ReferenceExpr
+                      name: "d"
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                BinaryExpr
+                  op: AND
+                  left:
+                    UnaryExpr
+                      op: NOT
+                      operand:
+                        BinaryExpr
+                          op: OR
+                          left:
+                            ReferenceExpr
+                              name: "x"
+                          right:
+                            ReferenceExpr
+                              name: "y"
+                  right:
+                    ReferenceExpr
+                      name: "z"
+        VarDeclStmt
+          names: ["result"]
+          value:
+            BinaryExpr
+              op: COALESCE
+              left:
+                ReferenceExpr
+                  name: "value"
+              right:
+                StringLiteral
+                  parts:
+                    TextPart
+                      text: "default"
+        VarDeclStmt
+          names: ["chained"]
+          value:
+            BinaryExpr
+              op: COALESCE
+              left:
+                ReferenceExpr
+                  name: "a"
+              right:
+                BinaryExpr
+                  op: COALESCE
+                  left:
+                    ReferenceExpr
+                      name: "b"
+                  right:
+                    ReferenceExpr
+                      name: "c"
+        VarDeclStmt
+          names: ["complex"]
+          value:
+            BinaryExpr
+              op: ADD
+              left:
+                BinaryExpr
+                  op: COALESCE
+                  left:
+                    MemberExpr
+                      target:
+                        ReferenceExpr
+                          name: "obj"
+                      member: "count"
+                      optional: true
+                  right:
+                    NumberLiteral
+                      value: "0"
+              right:
+                NumberLiteral
+                  value: "1"
+        VarDeclStmt
+          names: ["power"]
+          value:
+            BinaryExpr
+              op: POW
+              left:
+                ReferenceExpr
+                  name: "base"
+              right:
+                ReferenceExpr
+                  name: "exponent"
+        VarDeclStmt
+          names: ["rightAssociative"]
+          value:
+            BinaryExpr
+              op: POW
+              left:
+                NumberLiteral
+                  value: "2"
+              right:
+                BinaryExpr
+                  op: POW
+                  left:
+                    NumberLiteral
+                      value: "3"
+                  right:
+                    NumberLiteral
+                      value: "2"
+        VarDeclStmt
+          names: ["precedenceTest"]
+          value:
+            BinaryExpr
+              op: ADD
+              left:
+                NumberLiteral
+                  value: "2"
+              right:
+                BinaryExpr
+                  op: MUL
+                  left:
+                    BinaryExpr
+                      op: POW
+                      left:
+                        NumberLiteral
+                          value: "3"
+                      right:
+                        NumberLiteral
+                          value: "2"
+                  right:
+                    NumberLiteral
+                      value: "4"
+        VarDeclStmt
+          names: ["unaryInteraction"]
+          value:
+            BinaryExpr
+              op: POW
+              left:
+                UnaryExpr
+                  op: NEGATE
+                  operand:
+                    NumberLiteral
+                      value: "2"
+              right:
+                NumberLiteral
+                  value: "2"
+        VarDeclStmt
+          names: ["parentheses"]
+          value:
+            BinaryExpr
+              op: POW
+              left:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    NumberLiteral
+                      value: "2"
+                  right:
+                    NumberLiteral
+                      value: "3"
+              right:
+                NumberLiteral
+                  value: "2"
+        VarDeclStmt
+          names: ["floatingPoint"]
+          value:
+            BinaryExpr
+              op: POW
+              left:
+                NumberLiteral
+                  value: "2.5"
+              right:
+                NumberLiteral
+                  value: "3"
+        VarDeclStmt
+          names: ["scientific"]
+          value:
+            NumberLiteral
+              value: "1.5e10"
+        VarDeclStmt
+          names: ["negative"]
+          value:
+            NumberLiteral
+              value: "2.3e-5"
+        VarDeclStmt
+          names: ["uppercase"]
+          value:
+            NumberLiteral
+              value: "1E3"
+        VarDeclStmt
+          names: ["zeroExponent"]
+          value:
+            NumberLiteral
+              value: "3.14e0"
+        VarDeclStmt
+          names: ["explicitPlus"]
+          value:
+            NumberLiteral
+              value: "1e+5"
+        VarDeclStmt
+          names: ["mixed"]
+          value:
+            BinaryExpr
+              op: ADD
+              left:
+                NumberLiteral
+                  value: "1e3"
+              right:
+                NumberLiteral
+                  value: "2e2"
+        VarDeclStmt
+          names: ["complex"]
+          value:
+            BinaryExpr
+              op: MUL
+              left:
+                NumberLiteral
+                  value: "2.5e2"
+              right:
+                NumberLiteral
+                  value: "3e-1"
+        VarDeclStmt
+          names: ["precedence"]
+          value:
+            BinaryExpr
+              op: POW
+              left:
+                NumberLiteral
+                  value: "1e2"
+              right:
+                NumberLiteral
+                  value: "2"
+        VarDeclStmt
+          names: ["floating"]
+          value:
+            BinaryExpr
+              op: DIV
+              left:
+                NumberLiteral
+                  value: "1.25e-2"
+              right:
+                NumberLiteral
+                  value: "5e-3"

--- a/bazaar-parser/src/jvmTest/resources/testdata/optional-chaining.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/optional-chaining.bzr
@@ -1,0 +1,30 @@
+package optionalchaining
+
+func OptionalChaining() {
+    var result = obj?.property
+    var method = obj?.method()
+    var nested = obj?.nested?.property
+
+    var indexed = array?[0]
+    var deepIndexed = array?[0]?.field
+
+    var called = func?(param)
+    var chainedCall = obj?.method()?.result
+
+    if obj?.property {}
+    var conditional = obj?.value > 0
+
+    // Complex optional chaining from edge-cases.bzr
+    var complexResult = obj?.method()?.property
+    var complexIndexed = array?[0]?.field
+    var complexCalled = func?(param)?.result
+
+    // Complex optional chaining combinations - these work correctly
+    var complex = obj?.arr?[idx]?.call()
+    var mixedChain = items?[0]?.name
+    var deepChain = root?.child?.grandchild?.value
+
+    // Null coalescing with optional chaining
+    var arithmetic = (obj?.count ?? 0) + 1
+    var chained = obj?.value ?? other?.value ?? "default"
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/optional-chaining.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/optional-chaining.bzr.ast.golden
@@ -1,0 +1,268 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["optionalchaining"]
+  declarations:
+    FunctionDecl
+      name: "OptionalChaining"
+      body:
+        VarDeclStmt
+          names: ["result"]
+          value:
+            MemberExpr
+              target:
+                ReferenceExpr
+                  name: "obj"
+              member: "property"
+              optional: true
+        VarDeclStmt
+          names: ["method"]
+          value:
+            CallExpr
+              target:
+                MemberExpr
+                  target:
+                    ReferenceExpr
+                      name: "obj"
+                  member: "method"
+                  optional: true
+        VarDeclStmt
+          names: ["nested"]
+          value:
+            MemberExpr
+              target:
+                MemberExpr
+                  target:
+                    ReferenceExpr
+                      name: "obj"
+                  member: "nested"
+                  optional: true
+              member: "property"
+              optional: true
+        VarDeclStmt
+          names: ["indexed"]
+          value:
+            IndexExpr
+              target:
+                ReferenceExpr
+                  name: "array"
+              index:
+                NumberLiteral
+                  value: "0"
+              optional: true
+        VarDeclStmt
+          names: ["deepIndexed"]
+          value:
+            MemberExpr
+              target:
+                IndexExpr
+                  target:
+                    ReferenceExpr
+                      name: "array"
+                  index:
+                    NumberLiteral
+                      value: "0"
+                  optional: true
+              member: "field"
+              optional: true
+        VarDeclStmt
+          names: ["called"]
+          value:
+            CallExpr
+              target:
+                ReferenceExpr
+                  name: "func"
+              args:
+                Argument
+                  value:
+                    ReferenceExpr
+                      name: "param"
+              optional: true
+        VarDeclStmt
+          names: ["chainedCall"]
+          value:
+            MemberExpr
+              target:
+                CallExpr
+                  target:
+                    MemberExpr
+                      target:
+                        ReferenceExpr
+                          name: "obj"
+                      member: "method"
+                      optional: true
+              member: "result"
+              optional: true
+        IfStmt
+          fragments:
+            IfExprFragment
+              expr:
+                MemberExpr
+                  target:
+                    ReferenceExpr
+                      name: "obj"
+                  member: "property"
+                  optional: true
+        VarDeclStmt
+          names: ["conditional"]
+          value:
+            BinaryExpr
+              op: GT
+              left:
+                MemberExpr
+                  target:
+                    ReferenceExpr
+                      name: "obj"
+                  member: "value"
+                  optional: true
+              right:
+                NumberLiteral
+                  value: "0"
+        VarDeclStmt
+          names: ["complexResult"]
+          value:
+            MemberExpr
+              target:
+                CallExpr
+                  target:
+                    MemberExpr
+                      target:
+                        ReferenceExpr
+                          name: "obj"
+                      member: "method"
+                      optional: true
+              member: "property"
+              optional: true
+        VarDeclStmt
+          names: ["complexIndexed"]
+          value:
+            MemberExpr
+              target:
+                IndexExpr
+                  target:
+                    ReferenceExpr
+                      name: "array"
+                  index:
+                    NumberLiteral
+                      value: "0"
+                  optional: true
+              member: "field"
+              optional: true
+        VarDeclStmt
+          names: ["complexCalled"]
+          value:
+            MemberExpr
+              target:
+                CallExpr
+                  target:
+                    ReferenceExpr
+                      name: "func"
+                  args:
+                    Argument
+                      value:
+                        ReferenceExpr
+                          name: "param"
+                  optional: true
+              member: "result"
+              optional: true
+        VarDeclStmt
+          names: ["complex"]
+          value:
+            CallExpr
+              target:
+                MemberExpr
+                  target:
+                    IndexExpr
+                      target:
+                        MemberExpr
+                          target:
+                            ReferenceExpr
+                              name: "obj"
+                          member: "arr"
+                          optional: true
+                      index:
+                        ReferenceExpr
+                          name: "idx"
+                      optional: true
+                  member: "call"
+                  optional: true
+        VarDeclStmt
+          names: ["mixedChain"]
+          value:
+            MemberExpr
+              target:
+                IndexExpr
+                  target:
+                    ReferenceExpr
+                      name: "items"
+                  index:
+                    NumberLiteral
+                      value: "0"
+                  optional: true
+              member: "name"
+              optional: true
+        VarDeclStmt
+          names: ["deepChain"]
+          value:
+            MemberExpr
+              target:
+                MemberExpr
+                  target:
+                    MemberExpr
+                      target:
+                        ReferenceExpr
+                          name: "root"
+                      member: "child"
+                      optional: true
+                  member: "grandchild"
+                  optional: true
+              member: "value"
+              optional: true
+        VarDeclStmt
+          names: ["arithmetic"]
+          value:
+            BinaryExpr
+              op: ADD
+              left:
+                BinaryExpr
+                  op: COALESCE
+                  left:
+                    MemberExpr
+                      target:
+                        ReferenceExpr
+                          name: "obj"
+                      member: "count"
+                      optional: true
+                  right:
+                    NumberLiteral
+                      value: "0"
+              right:
+                NumberLiteral
+                  value: "1"
+        VarDeclStmt
+          names: ["chained"]
+          value:
+            BinaryExpr
+              op: COALESCE
+              left:
+                MemberExpr
+                  target:
+                    ReferenceExpr
+                      name: "obj"
+                  member: "value"
+                  optional: true
+              right:
+                BinaryExpr
+                  op: COALESCE
+                  left:
+                    MemberExpr
+                      target:
+                        ReferenceExpr
+                          name: "other"
+                      member: "value"
+                      optional: true
+                  right:
+                    StringLiteral
+                      parts:
+                        TextPart
+                          text: "default"

--- a/bazaar-parser/src/jvmTest/resources/testdata/references.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/references.bzr
@@ -1,0 +1,44 @@
+package references
+
+func References() {
+    // Basic property access
+    var prop = obj.property
+    var nested = obj.property.nested
+    var deep = obj.level1.level2.level3
+
+    // Method calls
+    var result = obj.method()
+    var chained = obj.method().property
+    var methodChain = obj.method1().method2()
+    var methodNested = obj.getData().process()
+
+    // Array indexing (non-optional)
+    var first = array[0]
+    var item = list[index]
+    var calculated = array[i + 1]
+    var expression = items[len(other) - 1]
+
+    // Map/object indexing
+    var value = map["key"]
+    var config = settings["theme"]
+    var dynamic = data[keyName]
+
+    // Matrix/nested indexing
+    var cell = matrix[row][col]
+    var deep = nested[outer][inner]
+    var combined = nested[outer][inner].property
+
+    // Complex mixed patterns
+    var complex1 = getData().items[0].name
+    var complex2 = obj.getArray()[index].method()
+    var complex3 = config.settings["theme"].colors[0]
+    var complex4 = root.children[i].data.value
+
+    // Indexing with complex expressions
+    var calculated1 = grid[x * width + y]
+    var calculated2 = buffer[offset + size]
+
+
+    // Preserved original complex optional pattern for comparison
+    var originalPattern = model?[0]?("hello, world!")?.foobar
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/references.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/references.bzr.ast.golden
@@ -1,0 +1,378 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["references"]
+  declarations:
+    FunctionDecl
+      name: "References"
+      body:
+        VarDeclStmt
+          names: ["prop"]
+          value:
+            MemberExpr
+              target:
+                ReferenceExpr
+                  name: "obj"
+              member: "property"
+        VarDeclStmt
+          names: ["nested"]
+          value:
+            MemberExpr
+              target:
+                MemberExpr
+                  target:
+                    ReferenceExpr
+                      name: "obj"
+                  member: "property"
+              member: "nested"
+        VarDeclStmt
+          names: ["deep"]
+          value:
+            MemberExpr
+              target:
+                MemberExpr
+                  target:
+                    MemberExpr
+                      target:
+                        ReferenceExpr
+                          name: "obj"
+                      member: "level1"
+                  member: "level2"
+              member: "level3"
+        VarDeclStmt
+          names: ["result"]
+          value:
+            CallExpr
+              target:
+                MemberExpr
+                  target:
+                    ReferenceExpr
+                      name: "obj"
+                  member: "method"
+        VarDeclStmt
+          names: ["chained"]
+          value:
+            MemberExpr
+              target:
+                CallExpr
+                  target:
+                    MemberExpr
+                      target:
+                        ReferenceExpr
+                          name: "obj"
+                      member: "method"
+              member: "property"
+        VarDeclStmt
+          names: ["methodChain"]
+          value:
+            CallExpr
+              target:
+                MemberExpr
+                  target:
+                    CallExpr
+                      target:
+                        MemberExpr
+                          target:
+                            ReferenceExpr
+                              name: "obj"
+                          member: "method1"
+                  member: "method2"
+        VarDeclStmt
+          names: ["methodNested"]
+          value:
+            CallExpr
+              target:
+                MemberExpr
+                  target:
+                    CallExpr
+                      target:
+                        MemberExpr
+                          target:
+                            ReferenceExpr
+                              name: "obj"
+                          member: "getData"
+                  member: "process"
+        VarDeclStmt
+          names: ["first"]
+          value:
+            IndexExpr
+              target:
+                ReferenceExpr
+                  name: "array"
+              index:
+                NumberLiteral
+                  value: "0"
+        VarDeclStmt
+          names: ["item"]
+          value:
+            IndexExpr
+              target:
+                ReferenceExpr
+                  name: "list"
+              index:
+                ReferenceExpr
+                  name: "index"
+        VarDeclStmt
+          names: ["calculated"]
+          value:
+            IndexExpr
+              target:
+                ReferenceExpr
+                  name: "array"
+              index:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    ReferenceExpr
+                      name: "i"
+                  right:
+                    NumberLiteral
+                      value: "1"
+        VarDeclStmt
+          names: ["expression"]
+          value:
+            IndexExpr
+              target:
+                ReferenceExpr
+                  name: "items"
+              index:
+                BinaryExpr
+                  op: SUB
+                  left:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "len"
+                      args:
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "other"
+                  right:
+                    NumberLiteral
+                      value: "1"
+        VarDeclStmt
+          names: ["value"]
+          value:
+            IndexExpr
+              target:
+                ReferenceExpr
+                  name: "map"
+              index:
+                StringLiteral
+                  parts:
+                    TextPart
+                      text: "key"
+        VarDeclStmt
+          names: ["config"]
+          value:
+            IndexExpr
+              target:
+                ReferenceExpr
+                  name: "settings"
+              index:
+                StringLiteral
+                  parts:
+                    TextPart
+                      text: "theme"
+        VarDeclStmt
+          names: ["dynamic"]
+          value:
+            IndexExpr
+              target:
+                ReferenceExpr
+                  name: "data"
+              index:
+                ReferenceExpr
+                  name: "keyName"
+        VarDeclStmt
+          names: ["cell"]
+          value:
+            IndexExpr
+              target:
+                IndexExpr
+                  target:
+                    ReferenceExpr
+                      name: "matrix"
+                  index:
+                    ReferenceExpr
+                      name: "row"
+              index:
+                ReferenceExpr
+                  name: "col"
+        VarDeclStmt
+          names: ["deep"]
+          value:
+            IndexExpr
+              target:
+                IndexExpr
+                  target:
+                    ReferenceExpr
+                      name: "nested"
+                  index:
+                    ReferenceExpr
+                      name: "outer"
+              index:
+                ReferenceExpr
+                  name: "inner"
+        VarDeclStmt
+          names: ["combined"]
+          value:
+            MemberExpr
+              target:
+                IndexExpr
+                  target:
+                    IndexExpr
+                      target:
+                        ReferenceExpr
+                          name: "nested"
+                      index:
+                        ReferenceExpr
+                          name: "outer"
+                  index:
+                    ReferenceExpr
+                      name: "inner"
+              member: "property"
+        VarDeclStmt
+          names: ["complex1"]
+          value:
+            MemberExpr
+              target:
+                IndexExpr
+                  target:
+                    MemberExpr
+                      target:
+                        CallExpr
+                          target:
+                            ReferenceExpr
+                              name: "getData"
+                      member: "items"
+                  index:
+                    NumberLiteral
+                      value: "0"
+              member: "name"
+        VarDeclStmt
+          names: ["complex2"]
+          value:
+            CallExpr
+              target:
+                MemberExpr
+                  target:
+                    IndexExpr
+                      target:
+                        CallExpr
+                          target:
+                            MemberExpr
+                              target:
+                                ReferenceExpr
+                                  name: "obj"
+                              member: "getArray"
+                      index:
+                        ReferenceExpr
+                          name: "index"
+                  member: "method"
+        VarDeclStmt
+          names: ["complex3"]
+          value:
+            IndexExpr
+              target:
+                MemberExpr
+                  target:
+                    IndexExpr
+                      target:
+                        MemberExpr
+                          target:
+                            ReferenceExpr
+                              name: "config"
+                          member: "settings"
+                      index:
+                        StringLiteral
+                          parts:
+                            TextPart
+                              text: "theme"
+                  member: "colors"
+              index:
+                NumberLiteral
+                  value: "0"
+        VarDeclStmt
+          names: ["complex4"]
+          value:
+            MemberExpr
+              target:
+                MemberExpr
+                  target:
+                    IndexExpr
+                      target:
+                        MemberExpr
+                          target:
+                            ReferenceExpr
+                              name: "root"
+                          member: "children"
+                      index:
+                        ReferenceExpr
+                          name: "i"
+                  member: "data"
+              member: "value"
+        VarDeclStmt
+          names: ["calculated1"]
+          value:
+            IndexExpr
+              target:
+                ReferenceExpr
+                  name: "grid"
+              index:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    BinaryExpr
+                      op: MUL
+                      left:
+                        ReferenceExpr
+                          name: "x"
+                      right:
+                        ReferenceExpr
+                          name: "width"
+                  right:
+                    ReferenceExpr
+                      name: "y"
+        VarDeclStmt
+          names: ["calculated2"]
+          value:
+            IndexExpr
+              target:
+                ReferenceExpr
+                  name: "buffer"
+              index:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    ReferenceExpr
+                      name: "offset"
+                  right:
+                    ReferenceExpr
+                      name: "size"
+        VarDeclStmt
+          names: ["originalPattern"]
+          value:
+            MemberExpr
+              target:
+                CallExpr
+                  target:
+                    IndexExpr
+                      target:
+                        ReferenceExpr
+                          name: "model"
+                      index:
+                        NumberLiteral
+                          value: "0"
+                      optional: true
+                  args:
+                    Argument
+                      value:
+                        StringLiteral
+                          parts:
+                            TextPart
+                              text: "hello, world!"
+                  optional: true
+              member: "foobar"
+              optional: true

--- a/bazaar-parser/src/jvmTest/resources/testdata/scientific.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/scientific.bzr
@@ -1,0 +1,44 @@
+package scientific
+
+func ScientificNotation() {
+    // Basic scientific notation
+    var basic = 1e5
+    var decimal = 1.5e10
+    var small = 2.3e-5
+
+    // Case variations
+    var lowercase = 1e3
+    var uppercase = 1E3
+
+    // Sign variations
+    var positive = 1e+10
+    var negative = 1e-10
+    var explicitPos = 1.5e+5
+    var explicitNeg = 1.5e-5
+
+    // Zero exponent
+    var zeroExp = 3.14e0
+    var zeroExpUpper = 2.71E0
+
+    // Edge cases
+    var noDecimal = 5e3
+    var withDecimal = 5.0e3
+    var trailingDecimal = 5.e3
+    var smallBase = 0.1e10
+
+    // Large numbers
+    var avogadro = 6.022e23
+    var planck = 6.626e-34
+    var lightSpeed = 2.998e8
+
+    // In arithmetic expressions
+    var sum = 1e3 + 2e3
+    var product = 3e2 * 4e-1
+    var division = 1e6 / 2e3
+    var power = 1e2 ** 2
+    var mixed = 1.5e3 + 2.5e-2 * 1e4
+
+    // With parentheses
+    var grouped = (1e3 + 2e3) * 3e-1
+    var complex = (1.5e2 + 2.5e1) / (3e-1 + 7e-2)
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/scientific.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/scientific.bzr.ast.golden
@@ -1,0 +1,199 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["scientific"]
+  declarations:
+    FunctionDecl
+      name: "ScientificNotation"
+      body:
+        VarDeclStmt
+          names: ["basic"]
+          value:
+            NumberLiteral
+              value: "1e5"
+        VarDeclStmt
+          names: ["decimal"]
+          value:
+            NumberLiteral
+              value: "1.5e10"
+        VarDeclStmt
+          names: ["small"]
+          value:
+            NumberLiteral
+              value: "2.3e-5"
+        VarDeclStmt
+          names: ["lowercase"]
+          value:
+            NumberLiteral
+              value: "1e3"
+        VarDeclStmt
+          names: ["uppercase"]
+          value:
+            NumberLiteral
+              value: "1E3"
+        VarDeclStmt
+          names: ["positive"]
+          value:
+            NumberLiteral
+              value: "1e+10"
+        VarDeclStmt
+          names: ["negative"]
+          value:
+            NumberLiteral
+              value: "1e-10"
+        VarDeclStmt
+          names: ["explicitPos"]
+          value:
+            NumberLiteral
+              value: "1.5e+5"
+        VarDeclStmt
+          names: ["explicitNeg"]
+          value:
+            NumberLiteral
+              value: "1.5e-5"
+        VarDeclStmt
+          names: ["zeroExp"]
+          value:
+            NumberLiteral
+              value: "3.14e0"
+        VarDeclStmt
+          names: ["zeroExpUpper"]
+          value:
+            NumberLiteral
+              value: "2.71E0"
+        VarDeclStmt
+          names: ["noDecimal"]
+          value:
+            NumberLiteral
+              value: "5e3"
+        VarDeclStmt
+          names: ["withDecimal"]
+          value:
+            NumberLiteral
+              value: "5.0e3"
+        VarDeclStmt
+          names: ["trailingDecimal"]
+          value:
+            NumberLiteral
+              value: "5.e3"
+        VarDeclStmt
+          names: ["smallBase"]
+          value:
+            NumberLiteral
+              value: "0.1e10"
+        VarDeclStmt
+          names: ["avogadro"]
+          value:
+            NumberLiteral
+              value: "6.022e23"
+        VarDeclStmt
+          names: ["planck"]
+          value:
+            NumberLiteral
+              value: "6.626e-34"
+        VarDeclStmt
+          names: ["lightSpeed"]
+          value:
+            NumberLiteral
+              value: "2.998e8"
+        VarDeclStmt
+          names: ["sum"]
+          value:
+            BinaryExpr
+              op: ADD
+              left:
+                NumberLiteral
+                  value: "1e3"
+              right:
+                NumberLiteral
+                  value: "2e3"
+        VarDeclStmt
+          names: ["product"]
+          value:
+            BinaryExpr
+              op: MUL
+              left:
+                NumberLiteral
+                  value: "3e2"
+              right:
+                NumberLiteral
+                  value: "4e-1"
+        VarDeclStmt
+          names: ["division"]
+          value:
+            BinaryExpr
+              op: DIV
+              left:
+                NumberLiteral
+                  value: "1e6"
+              right:
+                NumberLiteral
+                  value: "2e3"
+        VarDeclStmt
+          names: ["power"]
+          value:
+            BinaryExpr
+              op: POW
+              left:
+                NumberLiteral
+                  value: "1e2"
+              right:
+                NumberLiteral
+                  value: "2"
+        VarDeclStmt
+          names: ["mixed"]
+          value:
+            BinaryExpr
+              op: ADD
+              left:
+                NumberLiteral
+                  value: "1.5e3"
+              right:
+                BinaryExpr
+                  op: MUL
+                  left:
+                    NumberLiteral
+                      value: "2.5e-2"
+                  right:
+                    NumberLiteral
+                      value: "1e4"
+        VarDeclStmt
+          names: ["grouped"]
+          value:
+            BinaryExpr
+              op: MUL
+              left:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    NumberLiteral
+                      value: "1e3"
+                  right:
+                    NumberLiteral
+                      value: "2e3"
+              right:
+                NumberLiteral
+                  value: "3e-1"
+        VarDeclStmt
+          names: ["complex"]
+          value:
+            BinaryExpr
+              op: DIV
+              left:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    NumberLiteral
+                      value: "1.5e2"
+                  right:
+                    NumberLiteral
+                      value: "2.5e1"
+              right:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    NumberLiteral
+                      value: "3e-1"
+                  right:
+                    NumberLiteral
+                      value: "7e-2"

--- a/bazaar-parser/src/jvmTest/resources/testdata/strings.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/strings.bzr
@@ -1,0 +1,160 @@
+package strings
+
+data Messages {
+    answer string = "The answer is ${42}"
+    escaped string = "\""
+}
+
+data ComplexInterpolation {
+    arithmetic string = "Result: ${x + y * 2}"
+    functionCall string = "Hello ${getName()}"
+    variableRef string = "User: ${user.name}"
+    multiple string = "${first} and ${second}"
+    methodCall string = "Length: ${text.length()}"
+}
+
+data EscapeSequences {
+    newline string = "Line 1\nLine 2"
+    tab string = "Col1\tCol2"
+    backslash string = "Path\\to\\file"
+    mixed string = "Quote: \" Newline: \n Tab: \t Backslash: \\"
+    unicodeEscape string = "Unicode: \u0041\u0042"
+}
+
+data EdgeCases {
+    empty string = ""
+    whitespace string = "   "
+    specialChars string = "@#$%^&*()"
+    dollarSign string = "Cost: $5"
+    trailingBackslash string = "path\\"
+    multipleSpaces string = "word1    word2"
+    onlyNumbers string = "12345"
+}
+
+data ComplexScenarios {
+    arithmeticExpr string = "Result: ${(a + b) * c}"
+    booleanExpr string = "Status: ${isActive && isValid}"
+    chainedAccess string = "Data: ${obj.field.subfield}"
+    arrayAccess string = "Item: ${items[0]}"
+    powerOperator string = "Power: ${x ** 2}"
+    nullCoalescing string = "Value: ${value ?? defaultValue}"
+}
+
+data RealWorldUsage {
+    url string = "https://example.com/api/users/${userId}"
+    filePath string = "/home/user/documents/${filename}.txt"
+    sqlLike string = "SELECT * FROM users WHERE id = ${id}"
+    templateLike string = "Dear ${name}, welcome to ${appName}!"
+    logMessage string = "[${timestamp}] ${level}: ${message}"
+    cssClass string = "class-${type}-${variant}"
+}
+
+data StringConcatenation {
+    simpleConcat string = "Hello" + " " + "World"
+    mixedConcat string = "Count: " + "${count}"
+    multipleOps string = "A" + "B" + "C" + "${suffix}"
+}
+
+data NestedInterpolation {
+    // Test nested string interpolation scenarios
+    nestedBasic string = "Outer: ${getInner("Inner: ${x}")}"
+    nestedFunction string = "Result: ${format("Value: ${getValue()}")}"
+    nestedConditionalSimple string = "Status: ${getStatus(isActive, level)}"
+    nestedArithmetic string = "Calc: ${compute("Base: ${base} + ${offset}")}"
+    deepNesting string = "L1: ${level1("L2: ${level2("L3: ${level3}")}")}"
+}
+
+data BoundaryConditions {
+    // Test interpolation at string boundaries and empty cases
+    startingWithInterpolation string = "${greeting} world!"
+    endingWithInterpolation string = "Hello ${name}"
+    onlyInterpolation string = "${value}"
+    emptyStringLiteral string = ""
+    whitespaceOnly string = "   "
+    consecutiveInterpolations string = "${first}${second}${third}"
+    interpolationWithSpaces string = "${start} middle ${end}"
+    multipleSeparated string = "${a} and ${b} and ${c}"
+    interpolationInMiddle string = "start ${middle} end"
+}
+
+data ComplexExpressionInterpolation {
+    // Test complex expressions within interpolations
+    conditionalFunction string = "Status: ${getActiveStatus(isActive)}"
+    functionWithArgs string = "Result: ${func(a, b, c)}"
+    methodChaining string = "Value: ${obj.method1().method2().value}"
+    arrayAccessing string = "Item: ${items[index]}"
+    mapAccessing string = "Value: ${data["key"]}"
+    arithmeticInInterpolation string = "Sum: ${(a + b) * (c - d)}"
+    logicalOperations string = "Valid: ${flag1 && flag2 || flag3}"
+    comparisonOperations string = "Compare: ${x >= y && z <= w}"
+    nullCoalescingInString string = "Default: ${value ?? fallback ?? "none"}"
+    powerOperation string = "Power: ${base ** exponent}"
+    modOperation string = "Remainder: ${dividend % divisor}"
+    complexNested string = "Data: ${getData(user.id).process(options[0]).result}"
+    lambdaInString string = "Mapped: ${items.map({ (x) -> int in x * 2 })}"
+    lambdaInString string = "Mapped: ${items.map({:})}"
+    mappedItems string = "Mapped: ${mapDoubled(items)}"
+    conditionalNested string = "Chain: ${getChainedValue(a, b, c, d, e)}"
+}
+
+data RawDollarEdgeCases {
+    // Test raw dollar signs without interpolation
+    simpleDollar string = "Price: $5.99"
+    multipleDollars string = "Costs: $10, $20, $30"
+    dollarInMiddle string = "The $amount was paid"
+    dollarAtEnd string = "Total cost: $"
+    dollarAtStart string = "$variable assignment"
+    escapedDollar string = "Literal \\$dollar sign"
+    dollarWithoutBrace string = "Not interpolation: $variable"
+    dollarBeforeNumber string = "Amount: $123.45"
+    dollarInPath string = "Path: /home/$USER/documents"
+    dollarInUrl string = "URL: https://api.com/v1/$resource"
+    multipleRawDollars string = "$ $ $ multiple dollars"
+    dollarWithPunctuation string = "Cost: $1,234.56!"
+}
+
+data AdditionalEscapeSequences {
+    // Test additional escape sequences that might be supported
+    carriageReturn string = "Line 1\rLine 2"
+    formFeed string = "Page 1\fPage 2"
+    verticalTab string = "Col 1\vCol 2"
+    // Unicode escape sequences (supported)
+    unicodeShort string = "Unicode: \u0041"
+    unicodeLong string = "Unicode: \U00000041"
+    unicodeGreek string = "Greek: \u03B1\u03B2\u03B3"
+    unicodeEmoji string = "Emoji: \U0001F600\U0001F44D"
+    unicodeInInterpolation string = "Value: ${getValue()}, Unicode: \u2713"
+}
+
+data PotentiallyProblematicCases {
+    // These cases might cause parsing issues - all commented out for safety
+    invalidEscape string = "Bad escape: \q"
+    malformedInterpolation string = "Bad: $unclosed"
+    extraCloseBrace string = "Extra: ${value}}"
+
+    // Very long strings - for performance testing
+    veryLongString string = "This is a very long string that contains many characters to test the parser's ability to handle large string literals without any issues or performance degradation during the parsing phase of the Bazaar templating language processing pipeline"
+
+    // Strings with many interpolations - performance test
+    manyInterpolations string = "${a}${b}${c}${d}${e}${f}${g}${h}${i}${j}${k}${l}${m}${n}${o}${p}${q}${r}${s}${t}${u}${v}${w}${x}${y}${z}"
+
+    // Deeply nested expressions - complexity test
+    deeplyNestedExpressions string = "Result: ${obj.level1.level2.level3.level4.level5.getValue()}"
+}
+
+func StringOperations() {
+    var greeting = "Hello, ${name}!"
+    var path = "/api/v1/users/${userId}/profile"
+    var message = "Error ${code}: ${description}"
+
+    var complex = "Processing ${items.length} items"
+    var multiline = "First line\nSecond line\nThird line"
+    var escaped = "He said: \"Hello, world!\""
+
+    // Additional string operation tests
+    var interpolatedConcat = "Part1: ${part1}" + " Part2: ${part2}"
+    var mixedTypes = "Number: ${42} Boolean: ${true} Null: ${null}"
+    var nestedQuotes = "Outer \"Inner ${value} String\" End"
+    var pathLike = "/path/to/${resource}/${id}.${extension}"
+    var templateEngine = "{{${variable}}}"
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/strings.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/strings.bzr.ast.golden
@@ -1,0 +1,2051 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["strings"]
+  declarations:
+    DataDecl
+      name: "Messages"
+      members:
+        FieldDecl
+          name: "answer"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "The answer is "
+                InterpolationPart
+                  expr:
+                    NumberLiteral
+                      value: "42"
+        FieldDecl
+          name: "escaped"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                EscapePart
+                  text: "\""
+    DataDecl
+      name: "ComplexInterpolation"
+      members:
+        FieldDecl
+          name: "arithmetic"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Result: "
+                InterpolationPart
+                  expr:
+                    BinaryExpr
+                      op: ADD
+                      left:
+                        ReferenceExpr
+                          name: "x"
+                      right:
+                        BinaryExpr
+                          op: MUL
+                          left:
+                            ReferenceExpr
+                              name: "y"
+                          right:
+                            NumberLiteral
+                              value: "2"
+        FieldDecl
+          name: "functionCall"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Hello "
+                InterpolationPart
+                  expr:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "getName"
+        FieldDecl
+          name: "variableRef"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "User: "
+                InterpolationPart
+                  expr:
+                    MemberExpr
+                      target:
+                        ReferenceExpr
+                          name: "user"
+                      member: "name"
+        FieldDecl
+          name: "multiple"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "first"
+                TextPart
+                  text: " and "
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "second"
+        FieldDecl
+          name: "methodCall"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Length: "
+                InterpolationPart
+                  expr:
+                    CallExpr
+                      target:
+                        MemberExpr
+                          target:
+                            ReferenceExpr
+                              name: "text"
+                          member: "length"
+    DataDecl
+      name: "EscapeSequences"
+      members:
+        FieldDecl
+          name: "newline"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Line 1"
+                EscapePart
+                  text: "\n"
+                TextPart
+                  text: "Line 2"
+        FieldDecl
+          name: "tab"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Col1"
+                EscapePart
+                  text: "\t"
+                TextPart
+                  text: "Col2"
+        FieldDecl
+          name: "backslash"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Path"
+                EscapePart
+                  text: "\\"
+                TextPart
+                  text: "to"
+                EscapePart
+                  text: "\\"
+                TextPart
+                  text: "file"
+        FieldDecl
+          name: "mixed"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Quote: "
+                EscapePart
+                  text: "\""
+                TextPart
+                  text: " Newline: "
+                EscapePart
+                  text: "\n"
+                TextPart
+                  text: " Tab: "
+                EscapePart
+                  text: "\t"
+                TextPart
+                  text: " Backslash: "
+                EscapePart
+                  text: "\\"
+        FieldDecl
+          name: "unicodeEscape"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Unicode: "
+                EscapePart
+                  text: "\u0041"
+                EscapePart
+                  text: "\u0042"
+    DataDecl
+      name: "EdgeCases"
+      members:
+        FieldDecl
+          name: "empty"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+        FieldDecl
+          name: "whitespace"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "   "
+        FieldDecl
+          name: "specialChars"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "@#"
+                TextPart
+                  text: "$"
+                TextPart
+                  text: "%^&*()"
+        FieldDecl
+          name: "dollarSign"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Cost: "
+                TextPart
+                  text: "$"
+                TextPart
+                  text: "5"
+        FieldDecl
+          name: "trailingBackslash"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "path"
+                EscapePart
+                  text: "\\"
+        FieldDecl
+          name: "multipleSpaces"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "word1    word2"
+        FieldDecl
+          name: "onlyNumbers"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "12345"
+    DataDecl
+      name: "ComplexScenarios"
+      members:
+        FieldDecl
+          name: "arithmeticExpr"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Result: "
+                InterpolationPart
+                  expr:
+                    BinaryExpr
+                      op: MUL
+                      left:
+                        BinaryExpr
+                          op: ADD
+                          left:
+                            ReferenceExpr
+                              name: "a"
+                          right:
+                            ReferenceExpr
+                              name: "b"
+                      right:
+                        ReferenceExpr
+                          name: "c"
+        FieldDecl
+          name: "booleanExpr"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Status: "
+                InterpolationPart
+                  expr:
+                    BinaryExpr
+                      op: AND
+                      left:
+                        ReferenceExpr
+                          name: "isActive"
+                      right:
+                        ReferenceExpr
+                          name: "isValid"
+        FieldDecl
+          name: "chainedAccess"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Data: "
+                InterpolationPart
+                  expr:
+                    MemberExpr
+                      target:
+                        MemberExpr
+                          target:
+                            ReferenceExpr
+                              name: "obj"
+                          member: "field"
+                      member: "subfield"
+        FieldDecl
+          name: "arrayAccess"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Item: "
+                InterpolationPart
+                  expr:
+                    IndexExpr
+                      target:
+                        ReferenceExpr
+                          name: "items"
+                      index:
+                        NumberLiteral
+                          value: "0"
+        FieldDecl
+          name: "powerOperator"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Power: "
+                InterpolationPart
+                  expr:
+                    BinaryExpr
+                      op: POW
+                      left:
+                        ReferenceExpr
+                          name: "x"
+                      right:
+                        NumberLiteral
+                          value: "2"
+        FieldDecl
+          name: "nullCoalescing"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Value: "
+                InterpolationPart
+                  expr:
+                    BinaryExpr
+                      op: COALESCE
+                      left:
+                        ReferenceExpr
+                          name: "value"
+                      right:
+                        ReferenceExpr
+                          name: "defaultValue"
+    DataDecl
+      name: "RealWorldUsage"
+      members:
+        FieldDecl
+          name: "url"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "https://example.com/api/users/"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "userId"
+        FieldDecl
+          name: "filePath"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "/home/user/documents/"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "filename"
+                TextPart
+                  text: ".txt"
+        FieldDecl
+          name: "sqlLike"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "SELECT * FROM users WHERE id = "
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "id"
+        FieldDecl
+          name: "templateLike"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Dear "
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "name"
+                TextPart
+                  text: ", welcome to "
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "appName"
+                TextPart
+                  text: "!"
+        FieldDecl
+          name: "logMessage"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "["
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "timestamp"
+                TextPart
+                  text: "] "
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "level"
+                TextPart
+                  text: ": "
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "message"
+        FieldDecl
+          name: "cssClass"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "class-"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "type"
+                TextPart
+                  text: "-"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "variant"
+    DataDecl
+      name: "StringConcatenation"
+      members:
+        FieldDecl
+          name: "simpleConcat"
+          type:
+            ValueType
+              name: "string"
+          default:
+            BinaryExpr
+              op: ADD
+              left:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    StringLiteral
+                      parts:
+                        TextPart
+                          text: "Hello"
+                  right:
+                    StringLiteral
+                      parts:
+                        TextPart
+                          text: " "
+              right:
+                StringLiteral
+                  parts:
+                    TextPart
+                      text: "World"
+        FieldDecl
+          name: "mixedConcat"
+          type:
+            ValueType
+              name: "string"
+          default:
+            BinaryExpr
+              op: ADD
+              left:
+                StringLiteral
+                  parts:
+                    TextPart
+                      text: "Count: "
+              right:
+                StringLiteral
+                  parts:
+                    InterpolationPart
+                      expr:
+                        ReferenceExpr
+                          name: "count"
+        FieldDecl
+          name: "multipleOps"
+          type:
+            ValueType
+              name: "string"
+          default:
+            BinaryExpr
+              op: ADD
+              left:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    BinaryExpr
+                      op: ADD
+                      left:
+                        StringLiteral
+                          parts:
+                            TextPart
+                              text: "A"
+                      right:
+                        StringLiteral
+                          parts:
+                            TextPart
+                              text: "B"
+                  right:
+                    StringLiteral
+                      parts:
+                        TextPart
+                          text: "C"
+              right:
+                StringLiteral
+                  parts:
+                    InterpolationPart
+                      expr:
+                        ReferenceExpr
+                          name: "suffix"
+    DataDecl
+      name: "NestedInterpolation"
+      members:
+        FieldDecl
+          name: "nestedBasic"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Outer: "
+                InterpolationPart
+                  expr:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "getInner"
+                      args:
+                        Argument
+                          value:
+                            StringLiteral
+                              parts:
+                                TextPart
+                                  text: "Inner: "
+                                InterpolationPart
+                                  expr:
+                                    ReferenceExpr
+                                      name: "x"
+        FieldDecl
+          name: "nestedFunction"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Result: "
+                InterpolationPart
+                  expr:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "format"
+                      args:
+                        Argument
+                          value:
+                            StringLiteral
+                              parts:
+                                TextPart
+                                  text: "Value: "
+                                InterpolationPart
+                                  expr:
+                                    CallExpr
+                                      target:
+                                        ReferenceExpr
+                                          name: "getValue"
+        FieldDecl
+          name: "nestedConditionalSimple"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Status: "
+                InterpolationPart
+                  expr:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "getStatus"
+                      args:
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "isActive"
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "level"
+        FieldDecl
+          name: "nestedArithmetic"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Calc: "
+                InterpolationPart
+                  expr:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "compute"
+                      args:
+                        Argument
+                          value:
+                            StringLiteral
+                              parts:
+                                TextPart
+                                  text: "Base: "
+                                InterpolationPart
+                                  expr:
+                                    ReferenceExpr
+                                      name: "base"
+                                TextPart
+                                  text: " + "
+                                InterpolationPart
+                                  expr:
+                                    ReferenceExpr
+                                      name: "offset"
+        FieldDecl
+          name: "deepNesting"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "L1: "
+                InterpolationPart
+                  expr:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "level1"
+                      args:
+                        Argument
+                          value:
+                            StringLiteral
+                              parts:
+                                TextPart
+                                  text: "L2: "
+                                InterpolationPart
+                                  expr:
+                                    CallExpr
+                                      target:
+                                        ReferenceExpr
+                                          name: "level2"
+                                      args:
+                                        Argument
+                                          value:
+                                            StringLiteral
+                                              parts:
+                                                TextPart
+                                                  text: "L3: "
+                                                InterpolationPart
+                                                  expr:
+                                                    ReferenceExpr
+                                                      name: "level3"
+    DataDecl
+      name: "BoundaryConditions"
+      members:
+        FieldDecl
+          name: "startingWithInterpolation"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "greeting"
+                TextPart
+                  text: " world!"
+        FieldDecl
+          name: "endingWithInterpolation"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Hello "
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "name"
+        FieldDecl
+          name: "onlyInterpolation"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "value"
+        FieldDecl
+          name: "emptyStringLiteral"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+        FieldDecl
+          name: "whitespaceOnly"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "   "
+        FieldDecl
+          name: "consecutiveInterpolations"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "first"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "second"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "third"
+        FieldDecl
+          name: "interpolationWithSpaces"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "start"
+                TextPart
+                  text: " middle "
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "end"
+        FieldDecl
+          name: "multipleSeparated"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "a"
+                TextPart
+                  text: " and "
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "b"
+                TextPart
+                  text: " and "
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "c"
+        FieldDecl
+          name: "interpolationInMiddle"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "start "
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "middle"
+                TextPart
+                  text: " end"
+    DataDecl
+      name: "ComplexExpressionInterpolation"
+      members:
+        FieldDecl
+          name: "conditionalFunction"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Status: "
+                InterpolationPart
+                  expr:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "getActiveStatus"
+                      args:
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "isActive"
+        FieldDecl
+          name: "functionWithArgs"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Result: "
+                InterpolationPart
+                  expr:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "func"
+                      args:
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "a"
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "b"
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "c"
+        FieldDecl
+          name: "methodChaining"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Value: "
+                InterpolationPart
+                  expr:
+                    MemberExpr
+                      target:
+                        CallExpr
+                          target:
+                            MemberExpr
+                              target:
+                                CallExpr
+                                  target:
+                                    MemberExpr
+                                      target:
+                                        ReferenceExpr
+                                          name: "obj"
+                                      member: "method1"
+                              member: "method2"
+                      member: "value"
+        FieldDecl
+          name: "arrayAccessing"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Item: "
+                InterpolationPart
+                  expr:
+                    IndexExpr
+                      target:
+                        ReferenceExpr
+                          name: "items"
+                      index:
+                        ReferenceExpr
+                          name: "index"
+        FieldDecl
+          name: "mapAccessing"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Value: "
+                InterpolationPart
+                  expr:
+                    IndexExpr
+                      target:
+                        ReferenceExpr
+                          name: "data"
+                      index:
+                        StringLiteral
+                          parts:
+                            TextPart
+                              text: "key"
+        FieldDecl
+          name: "arithmeticInInterpolation"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Sum: "
+                InterpolationPart
+                  expr:
+                    BinaryExpr
+                      op: MUL
+                      left:
+                        BinaryExpr
+                          op: ADD
+                          left:
+                            ReferenceExpr
+                              name: "a"
+                          right:
+                            ReferenceExpr
+                              name: "b"
+                      right:
+                        BinaryExpr
+                          op: SUB
+                          left:
+                            ReferenceExpr
+                              name: "c"
+                          right:
+                            ReferenceExpr
+                              name: "d"
+        FieldDecl
+          name: "logicalOperations"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Valid: "
+                InterpolationPart
+                  expr:
+                    BinaryExpr
+                      op: OR
+                      left:
+                        BinaryExpr
+                          op: AND
+                          left:
+                            ReferenceExpr
+                              name: "flag1"
+                          right:
+                            ReferenceExpr
+                              name: "flag2"
+                      right:
+                        ReferenceExpr
+                          name: "flag3"
+        FieldDecl
+          name: "comparisonOperations"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Compare: "
+                InterpolationPart
+                  expr:
+                    BinaryExpr
+                      op: AND
+                      left:
+                        BinaryExpr
+                          op: GTE
+                          left:
+                            ReferenceExpr
+                              name: "x"
+                          right:
+                            ReferenceExpr
+                              name: "y"
+                      right:
+                        BinaryExpr
+                          op: LTE
+                          left:
+                            ReferenceExpr
+                              name: "z"
+                          right:
+                            ReferenceExpr
+                              name: "w"
+        FieldDecl
+          name: "nullCoalescingInString"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Default: "
+                InterpolationPart
+                  expr:
+                    BinaryExpr
+                      op: COALESCE
+                      left:
+                        ReferenceExpr
+                          name: "value"
+                      right:
+                        BinaryExpr
+                          op: COALESCE
+                          left:
+                            ReferenceExpr
+                              name: "fallback"
+                          right:
+                            StringLiteral
+                              parts:
+                                TextPart
+                                  text: "none"
+        FieldDecl
+          name: "powerOperation"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Power: "
+                InterpolationPart
+                  expr:
+                    BinaryExpr
+                      op: POW
+                      left:
+                        ReferenceExpr
+                          name: "base"
+                      right:
+                        ReferenceExpr
+                          name: "exponent"
+        FieldDecl
+          name: "modOperation"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Remainder: "
+                InterpolationPart
+                  expr:
+                    BinaryExpr
+                      op: MOD
+                      left:
+                        ReferenceExpr
+                          name: "dividend"
+                      right:
+                        ReferenceExpr
+                          name: "divisor"
+        FieldDecl
+          name: "complexNested"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Data: "
+                InterpolationPart
+                  expr:
+                    MemberExpr
+                      target:
+                        CallExpr
+                          target:
+                            MemberExpr
+                              target:
+                                CallExpr
+                                  target:
+                                    ReferenceExpr
+                                      name: "getData"
+                                  args:
+                                    Argument
+                                      value:
+                                        MemberExpr
+                                          target:
+                                            ReferenceExpr
+                                              name: "user"
+                                          member: "id"
+                              member: "process"
+                          args:
+                            Argument
+                              value:
+                                IndexExpr
+                                  target:
+                                    ReferenceExpr
+                                      name: "options"
+                                  index:
+                                    NumberLiteral
+                                      value: "0"
+                      member: "result"
+        FieldDecl
+          name: "lambdaInString"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Mapped: "
+                InterpolationPart
+                  expr:
+                    CallExpr
+                      target:
+                        MemberExpr
+                          target:
+                            ReferenceExpr
+                              name: "items"
+                          member: "map"
+                      args:
+                        Argument
+                          value:
+                            LambdaExpr
+                              params:
+                                LambdaParam
+                                  name: "x"
+                              returnType:
+                                ValueType
+                                  name: "int"
+                              body:
+                                ExprStmt
+                                  expr:
+                                    BinaryExpr
+                                      op: MUL
+                                      left:
+                                        ReferenceExpr
+                                          name: "x"
+                                      right:
+                                        NumberLiteral
+                                          value: "2"
+        FieldDecl
+          name: "lambdaInString"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Mapped: "
+                InterpolationPart
+                  expr:
+                    CallExpr
+                      target:
+                        MemberExpr
+                          target:
+                            ReferenceExpr
+                              name: "items"
+                          member: "map"
+                      args:
+                        Argument
+                          value:
+                            MapLiteral
+        FieldDecl
+          name: "mappedItems"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Mapped: "
+                InterpolationPart
+                  expr:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "mapDoubled"
+                      args:
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "items"
+        FieldDecl
+          name: "conditionalNested"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Chain: "
+                InterpolationPart
+                  expr:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "getChainedValue"
+                      args:
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "a"
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "b"
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "c"
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "d"
+                        Argument
+                          value:
+                            ReferenceExpr
+                              name: "e"
+    DataDecl
+      name: "RawDollarEdgeCases"
+      members:
+        FieldDecl
+          name: "simpleDollar"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Price: "
+                TextPart
+                  text: "$"
+                TextPart
+                  text: "5.99"
+        FieldDecl
+          name: "multipleDollars"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Costs: "
+                TextPart
+                  text: "$"
+                TextPart
+                  text: "10, "
+                TextPart
+                  text: "$"
+                TextPart
+                  text: "20, "
+                TextPart
+                  text: "$"
+                TextPart
+                  text: "30"
+        FieldDecl
+          name: "dollarInMiddle"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "The "
+                TextPart
+                  text: "$"
+                TextPart
+                  text: "amount was paid"
+        FieldDecl
+          name: "dollarAtEnd"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Total cost: "
+                TextPart
+                  text: "$"
+        FieldDecl
+          name: "dollarAtStart"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "$"
+                TextPart
+                  text: "variable assignment"
+        FieldDecl
+          name: "escapedDollar"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Literal "
+                EscapePart
+                  text: "\\"
+                TextPart
+                  text: "$"
+                TextPart
+                  text: "dollar sign"
+        FieldDecl
+          name: "dollarWithoutBrace"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Not interpolation: "
+                TextPart
+                  text: "$"
+                TextPart
+                  text: "variable"
+        FieldDecl
+          name: "dollarBeforeNumber"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Amount: "
+                TextPart
+                  text: "$"
+                TextPart
+                  text: "123.45"
+        FieldDecl
+          name: "dollarInPath"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Path: /home/"
+                TextPart
+                  text: "$"
+                TextPart
+                  text: "USER/documents"
+        FieldDecl
+          name: "dollarInUrl"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "URL: https://api.com/v1/"
+                TextPart
+                  text: "$"
+                TextPart
+                  text: "resource"
+        FieldDecl
+          name: "multipleRawDollars"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "$"
+                TextPart
+                  text: " "
+                TextPart
+                  text: "$"
+                TextPart
+                  text: " "
+                TextPart
+                  text: "$"
+                TextPart
+                  text: " multiple dollars"
+        FieldDecl
+          name: "dollarWithPunctuation"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Cost: "
+                TextPart
+                  text: "$"
+                TextPart
+                  text: "1,234.56!"
+    DataDecl
+      name: "AdditionalEscapeSequences"
+      members:
+        FieldDecl
+          name: "carriageReturn"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Line 1"
+                EscapePart
+                  text: "\r"
+                TextPart
+                  text: "Line 2"
+        FieldDecl
+          name: "formFeed"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Page 1"
+                TextPart
+                  text: "Page 2"
+        FieldDecl
+          name: "verticalTab"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Col 1"
+                TextPart
+                  text: "Col 2"
+        FieldDecl
+          name: "unicodeShort"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Unicode: "
+                EscapePart
+                  text: "\u0041"
+        FieldDecl
+          name: "unicodeLong"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Unicode: "
+                EscapePart
+                  text: "\U00000041"
+        FieldDecl
+          name: "unicodeGreek"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Greek: "
+                EscapePart
+                  text: "\u03B1"
+                EscapePart
+                  text: "\u03B2"
+                EscapePart
+                  text: "\u03B3"
+        FieldDecl
+          name: "unicodeEmoji"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Emoji: "
+                EscapePart
+                  text: "\U0001F600"
+                EscapePart
+                  text: "\U0001F44D"
+        FieldDecl
+          name: "unicodeInInterpolation"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Value: "
+                InterpolationPart
+                  expr:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "getValue"
+                TextPart
+                  text: ", Unicode: "
+                EscapePart
+                  text: "\u2713"
+    DataDecl
+      name: "PotentiallyProblematicCases"
+      members:
+        FieldDecl
+          name: "invalidEscape"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Bad escape: "
+        FieldDecl
+          name: "malformedInterpolation"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Bad: "
+                TextPart
+                  text: "$"
+                TextPart
+                  text: "unclosed"
+        FieldDecl
+          name: "extraCloseBrace"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Extra: "
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "value"
+                TextPart
+                  text: "}"
+        FieldDecl
+          name: "veryLongString"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "This is a very long string that contains many characters to test the parser's ability to handle large string literals without any issues or performance degradation during the parsing phase of the Bazaar templating language processing pipeline"
+        FieldDecl
+          name: "manyInterpolations"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "a"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "b"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "c"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "d"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "e"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "f"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "g"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "h"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "i"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "j"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "k"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "l"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "m"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "n"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "o"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "p"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "q"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "r"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "s"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "t"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "u"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "v"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "w"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "x"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "y"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "z"
+        FieldDecl
+          name: "deeplyNestedExpressions"
+          type:
+            ValueType
+              name: "string"
+          default:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Result: "
+                InterpolationPart
+                  expr:
+                    CallExpr
+                      target:
+                        MemberExpr
+                          target:
+                            MemberExpr
+                              target:
+                                MemberExpr
+                                  target:
+                                    MemberExpr
+                                      target:
+                                        MemberExpr
+                                          target:
+                                            MemberExpr
+                                              target:
+                                                ReferenceExpr
+                                                  name: "obj"
+                                              member: "level1"
+                                          member: "level2"
+                                      member: "level3"
+                                  member: "level4"
+                              member: "level5"
+                          member: "getValue"
+    FunctionDecl
+      name: "StringOperations"
+      body:
+        VarDeclStmt
+          names: ["greeting"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Hello, "
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "name"
+                TextPart
+                  text: "!"
+        VarDeclStmt
+          names: ["path"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "/api/v1/users/"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "userId"
+                TextPart
+                  text: "/profile"
+        VarDeclStmt
+          names: ["message"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Error "
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "code"
+                TextPart
+                  text: ": "
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "description"
+        VarDeclStmt
+          names: ["complex"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Processing "
+                InterpolationPart
+                  expr:
+                    MemberExpr
+                      target:
+                        ReferenceExpr
+                          name: "items"
+                      member: "length"
+                TextPart
+                  text: " items"
+        VarDeclStmt
+          names: ["multiline"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "First line"
+                EscapePart
+                  text: "\n"
+                TextPart
+                  text: "Second line"
+                EscapePart
+                  text: "\n"
+                TextPart
+                  text: "Third line"
+        VarDeclStmt
+          names: ["escaped"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "He said: "
+                EscapePart
+                  text: "\""
+                TextPart
+                  text: "Hello, world!"
+                EscapePart
+                  text: "\""
+        VarDeclStmt
+          names: ["interpolatedConcat"]
+          value:
+            BinaryExpr
+              op: ADD
+              left:
+                StringLiteral
+                  parts:
+                    TextPart
+                      text: "Part1: "
+                    InterpolationPart
+                      expr:
+                        ReferenceExpr
+                          name: "part1"
+              right:
+                StringLiteral
+                  parts:
+                    TextPart
+                      text: " Part2: "
+                    InterpolationPart
+                      expr:
+                        ReferenceExpr
+                          name: "part2"
+        VarDeclStmt
+          names: ["mixedTypes"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Number: "
+                InterpolationPart
+                  expr:
+                    NumberLiteral
+                      value: "42"
+                TextPart
+                  text: " Boolean: "
+                InterpolationPart
+                  expr:
+                    BoolLiteral
+                      value: true
+                TextPart
+                  text: " Null: "
+                InterpolationPart
+                  expr:
+                    NullLiteral
+        VarDeclStmt
+          names: ["nestedQuotes"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "Outer "
+                EscapePart
+                  text: "\""
+                TextPart
+                  text: "Inner "
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "value"
+                TextPart
+                  text: " String"
+                EscapePart
+                  text: "\""
+                TextPart
+                  text: " End"
+        VarDeclStmt
+          names: ["pathLike"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "/path/to/"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "resource"
+                TextPart
+                  text: "/"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "id"
+                TextPart
+                  text: "."
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "extension"
+        VarDeclStmt
+          names: ["templateEngine"]
+          value:
+            StringLiteral
+              parts:
+                TextPart
+                  text: "{{"
+                InterpolationPart
+                  expr:
+                    ReferenceExpr
+                      name: "variable"
+                TextPart
+                  text: "}}"

--- a/bazaar-parser/src/jvmTest/resources/testdata/switches.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/switches.bzr
@@ -1,0 +1,12 @@
+package switches
+
+func Switches() {
+    switch expression {
+    case expr1:
+    case value1:
+        2 + 2
+        foo()
+    default:
+        1 + 1
+    }
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/switches.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/switches.bzr.ast.golden
@@ -1,0 +1,49 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["switches"]
+  declarations:
+    FunctionDecl
+      name: "Switches"
+      body:
+        SwitchStmt
+          expr:
+            ReferenceExpr
+              name: "expression"
+          cases:
+            SwitchCase
+              expr:
+                ReferenceExpr
+                  name: "expr1"
+            SwitchCase
+              expr:
+                ReferenceExpr
+                  name: "value1"
+              body:
+                ExprStmt
+                  expr:
+                    BinaryExpr
+                      op: ADD
+                      left:
+                        NumberLiteral
+                          value: "2"
+                      right:
+                        NumberLiteral
+                          value: "2"
+                ExprStmt
+                  expr:
+                    CallExpr
+                      target:
+                        ReferenceExpr
+                          name: "foo"
+          default:
+            ExprStmt
+              expr:
+                BinaryExpr
+                  op: ADD
+                  left:
+                    NumberLiteral
+                      value: "1"
+                  right:
+                    NumberLiteral
+                      value: "1"

--- a/bazaar-parser/src/jvmTest/resources/testdata/todo.bzr
+++ b/bazaar-parser/src/jvmTest/resources/testdata/todo.bzr
@@ -1,0 +1,102 @@
+package todo
+
+// This file tracks language features that are not yet supported but may be added in the future.
+// Each section contains commented-out examples and TODO comments for systematic tracking.
+
+func UnsupportedNumericLiterals() {
+    // TODO: Binary number literals (0b prefix)
+    // Support for: 0b1010, 0b1111, 0B0001
+    // var binaryValue int = 0b1010
+    // var binaryFlags int = 0b11110000
+
+    // TODO: Hexadecimal number literals (0x prefix)
+    // Support for: 0xFF, 0x1A2B, 0X123
+    // var hexValue int = 0xFF
+    // var hexColor int = 0x1A2B3C
+
+    // TODO: Octal number literals (0o prefix and legacy 0 prefix)
+    // Support for: 0o755, 0o644, 0755 (legacy)
+    // var octalPermissions int = 0o755
+    // var legacyOctal int = 0644
+}
+
+func UnsupportedStringEscapes() {
+    // TODO: Hexadecimal escape sequences (\x prefix)
+    // Support for: \x41 (represents 'A'), \xFF
+    // Note: Not supported in Kotlin, would need conversion to \u0041
+    // var hexEscape string = "Hex character: \x41"
+    // var hexBytes string = "Byte sequence: \x00\xFF\x7F"
+
+    // TODO: Octal escape sequences (\nnn format)
+    // Support for: \101 (represents 'A'), \377
+    // Note: Not supported in Kotlin/Swift, would need conversion
+    // var octalEscape string = "Octal character: \101"
+    // var octalNull string = "Null byte: \000"
+
+    // TODO: Raw string literals (multi-line, no escaping)
+    // Support for: """raw content""" or similar syntax
+    // var rawString string = """This would be
+    // a multi-line string with no escape processing
+    // including literal \n and ${expressions}"""
+}
+
+func UnsupportedOperators() {
+    // TODO: Ternary conditional operator (? :)
+    // Useful for conditional expressions, especially in string interpolation
+    // var result string = condition ? "yes" : "no"
+    // var interpolated string = "Status: ${isActive ? "online" : "offline"}"
+}
+
+func UnsupportedControlFlow() {
+    // TODO: Break and continue statements for loops
+    // Standard loop control flow
+    // for item in items {
+    //     if shouldSkip(item) { continue }
+    //     if shouldStop(item) { break }
+    //     process(item)
+    // }
+
+    // TODO: Labeled break/continue for nested loops
+    // outer: for i in range1 {
+    //     for j in range2 {
+    //         if condition { break outer }
+    //     }
+    // }
+
+    // TODO: Guard statements for early returns
+    // guard condition else { return }
+}
+
+func UnsupportedDataStructures() {
+    // TODO: Set literals [unique collection]
+    // var setValues set = {1, 2, 3, 1} // would contain {1, 2, 3}
+
+    // TODO: Tuple literals and destructuring
+    // var coordinate tuple = (x: 10, y: 20)
+    // var (x, y) = coordinate
+
+    // TODO: Range expressions
+    // var numbers range = 1..10
+    // var chars range = 'a'..'z'
+}
+
+func UnsupportedAdvancedFeatures() {
+    // TODO: Async/await syntax
+    // var result = await fetchData()
+
+    // TODO: Pattern matching/when expressions
+    // var result = when (value) {
+    //     is String -> "text"
+    //     is Int -> "number"
+    //     else -> "unknown"
+    // }
+
+    // TODO: Extension functions
+    // extend String {
+    //     func reversed() -> String { ... }
+    // }
+
+    // TODO: Type casting and any types
+    // var number = 42.0 as? int
+    // var something any = "something"
+}

--- a/bazaar-parser/src/jvmTest/resources/testdata/todo.bzr.ast.golden
+++ b/bazaar-parser/src/jvmTest/resources/testdata/todo.bzr.ast.golden
@@ -1,0 +1,17 @@
+BazaarFile
+  packageDecl:
+    PackageDecl
+      segments: ["todo"]
+  declarations:
+    FunctionDecl
+      name: "UnsupportedNumericLiterals"
+    FunctionDecl
+      name: "UnsupportedStringEscapes"
+    FunctionDecl
+      name: "UnsupportedOperators"
+    FunctionDecl
+      name: "UnsupportedControlFlow"
+    FunctionDecl
+      name: "UnsupportedDataStructures"
+    FunctionDecl
+      name: "UnsupportedAdvancedFeatures"


### PR DESCRIPTION
## Summary
- Add `AstSerializer` for golden-file-based AST validation, with unit tests and a JVM golden test runner
- Guard empty `elseBody` and `default` lists with `isNotEmpty()` to avoid emitting dangling labels in serialized output
- Rename misleading `binaryExpr` test to `functionDeclWithParams`

## Test plan
- [x] `./gradlew :bazaar-parser:allTests` passes on all targets
- [x] Golden files regenerated for `ifs` and `switches` tests
- [x] Verified no other golden files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)