### PR TITLE
Add bazaar-cli module (#33)

### DIFF
--- a/bazaar-cli/build.gradle.kts
+++ b/bazaar-cli/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    id("com.bazaar.build")
+}
+
+kotlin {
+    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget> {
+        binaries {
+            executable {
+                entryPoint = "com.bazaar.cli.main"
+            }
+        }
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation(projects.bazaarParser)
+                implementation(libs.kotlinx.io.core)
+            }
+        }
+    }
+}

--- a/bazaar-cli/src/commonMain/kotlin/com/bazaar/cli/Args.kt
+++ b/bazaar-cli/src/commonMain/kotlin/com/bazaar/cli/Args.kt
@@ -1,0 +1,51 @@
+package com.bazaar.cli
+
+enum class OutputFormat { TEXT, JSON }
+
+data class CliArgs(
+    val files: List<String>,
+    val format: OutputFormat = OutputFormat.TEXT,
+    val check: Boolean = false,
+)
+
+sealed class ArgsResult {
+    data class Success(val args: CliArgs) : ArgsResult()
+    data class Error(val message: String) : ArgsResult()
+    data object Help : ArgsResult()
+}
+
+fun parseArgs(args: Array<String>): ArgsResult {
+    var format = OutputFormat.TEXT
+    var check = false
+    val files = mutableListOf<String>()
+
+    var i = 0
+    while (i < args.size) {
+        when (args[i]) {
+            "--help", "-h" -> return ArgsResult.Help
+            "--check" -> check = true
+            "--format" -> {
+                i++
+                if (i >= args.size) {
+                    return ArgsResult.Error("--format requires an argument (text or json)")
+                }
+                format = when (args[i].lowercase()) {
+                    "text" -> OutputFormat.TEXT
+                    "json" -> OutputFormat.JSON
+                    else -> return ArgsResult.Error("Unknown format: ${args[i]}. Expected 'text' or 'json'.")
+                }
+            }
+            else -> {
+                if (args[i].startsWith("-")) {
+                    return ArgsResult.Error("Unknown option: ${args[i]}")
+                }
+                files.add(args[i])
+            }
+        }
+        i++
+    }
+
+    if (files.isEmpty()) return ArgsResult.Error("No input files specified.")
+
+    return ArgsResult.Success(CliArgs(files, format, check))
+}

--- a/bazaar-cli/src/commonMain/kotlin/com/bazaar/cli/Formatters.kt
+++ b/bazaar-cli/src/commonMain/kotlin/com/bazaar/cli/Formatters.kt
@@ -1,0 +1,69 @@
+package com.bazaar.cli
+
+import com.bazaar.parser.ParseResult
+import com.bazaar.parser.ast.AstSerializer
+import com.bazaar.parser.serializeDiagnostics
+
+fun formatTextResult(filePath: String, result: ParseResult, multiFile: Boolean): String {
+    val sb = StringBuilder()
+    if (multiFile) {
+        sb.appendLine("--- $filePath ---")
+    }
+    val ast = result.ast
+    if (ast != null) {
+        sb.append(AstSerializer.serialize(ast))
+    }
+    if (result.diagnostics.isNotEmpty()) {
+        sb.append(serializeDiagnostics(result.diagnostics))
+    }
+    return sb.toString()
+}
+
+fun formatJsonResult(filePath: String, result: ParseResult): String {
+    val sb = StringBuilder()
+    sb.appendLine("{")
+    sb.appendLine("  \"file\": ${jsonString(filePath)},")
+    sb.appendLine("  \"status\": ${if (result.hasErrors) "\"error\"" else "\"ok\""},")
+    val ast = result.ast
+    if (ast != null) {
+        sb.appendLine("  \"ast\": ${jsonString(AstSerializer.serialize(ast))},")
+    }
+    sb.append("  \"diagnostics\": [")
+    if (result.diagnostics.isNotEmpty()) {
+        sb.appendLine()
+        result.diagnostics.forEachIndexed { index, diag ->
+            sb.append("    {")
+            sb.append("\"severity\": ${jsonString(diag.severity.name)}, ")
+            sb.append("\"line\": ${diag.line}, ")
+            sb.append("\"column\": ${diag.column}, ")
+            sb.append("\"message\": ${jsonString(diag.message)}")
+            sb.append("}")
+            if (index < result.diagnostics.size - 1) sb.append(",")
+            sb.appendLine()
+        }
+        sb.append("  ")
+    }
+    sb.appendLine("]")
+    sb.append("}")
+    return sb.toString()
+}
+
+private fun jsonString(value: String): String {
+    val sb = StringBuilder("\"")
+    for (c in value) {
+        when (c) {
+            '"' -> sb.append("\\\"")
+            '\\' -> sb.append("\\\\")
+            '\n' -> sb.append("\\n")
+            '\r' -> sb.append("\\r")
+            '\t' -> sb.append("\\t")
+            else -> if (c < '\u0020') {
+                sb.append("\\u${c.code.toString(16).padStart(4, '0')}")
+            } else {
+                sb.append(c)
+            }
+        }
+    }
+    sb.append('"')
+    return sb.toString()
+}

--- a/bazaar-cli/src/commonMain/kotlin/com/bazaar/cli/Main.kt
+++ b/bazaar-cli/src/commonMain/kotlin/com/bazaar/cli/Main.kt
@@ -1,0 +1,85 @@
+package com.bazaar.cli
+
+import com.bazaar.parser.BazaarParser
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readString
+import kotlin.system.exitProcess
+
+fun main(args: Array<String>) {
+    when (val result = parseArgs(args)) {
+        is ArgsResult.Help -> {
+            println(usageText())
+            exitProcess(0)
+        }
+        is ArgsResult.Error -> {
+            printStderr("Error: ${result.message}")
+            printStderr(usageText())
+            exitProcess(2)
+        }
+        is ArgsResult.Success -> exitProcess(run(result.args))
+    }
+}
+
+private fun usageText(): String =
+    """
+    |Usage: bazaar-cli [options] <file>...
+    |
+    |Options:
+    |  --format text|json  Output format (default: text)
+    |  --check             Check for parse errors only (no output on success)
+    |  -h, --help          Show this help message
+    """.trimMargin()
+
+
+private fun run(args: CliArgs): Int {
+    val multiFile = args.files.size > 1
+    var hasErrors = false
+    val jsonResults = if (args.format == OutputFormat.JSON && !args.check) mutableListOf<String>() else null
+
+    for (filePath in args.files) {
+        val source = try {
+            SystemFileSystem.source(Path(filePath)).buffered().use { it.readString() }
+        } catch (e: Exception) {
+            printStderr("Error: Cannot read file: $filePath (${e.message})")
+            hasErrors = true
+            continue
+        }
+
+        val result = BazaarParser.parseWithDiagnostics(source)
+
+        if (result.hasErrors) {
+            hasErrors = true
+        }
+
+        if (args.check) {
+            if (result.hasErrors) {
+                printStderr("$filePath: parse errors found")
+                for (diag in result.diagnostics) {
+                    printStderr("  ${diag.severity} ${diag.line}:${diag.column} ${diag.message}")
+                }
+            }
+        } else {
+            when (args.format) {
+                OutputFormat.TEXT -> print(formatTextResult(filePath, result, multiFile))
+                OutputFormat.JSON -> jsonResults!!.add(formatJsonResult(filePath, result))
+            }
+        }
+    }
+
+    if (jsonResults != null) {
+        if (multiFile) {
+            println("[")
+            jsonResults.forEachIndexed { index, json ->
+                print(json)
+                if (index < jsonResults.size - 1) println(",") else println()
+            }
+            println("]")
+        } else {
+            jsonResults.forEach { println(it) }
+        }
+    }
+
+    return if (hasErrors) 1 else 0
+}

--- a/bazaar-cli/src/commonMain/kotlin/com/bazaar/cli/Platform.kt
+++ b/bazaar-cli/src/commonMain/kotlin/com/bazaar/cli/Platform.kt
@@ -1,0 +1,3 @@
+package com.bazaar.cli
+
+internal expect fun printStderr(message: String)

--- a/bazaar-cli/src/nativeMain/kotlin/com/bazaar/cli/Platform.kt
+++ b/bazaar-cli/src/nativeMain/kotlin/com/bazaar/cli/Platform.kt
@@ -1,0 +1,11 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.bazaar.cli
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.fprintf
+import platform.posix.stderr
+
+internal actual fun printStderr(message: String) {
+    fprintf(stderr, "%s\n", message)
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,3 +16,4 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 rootProject.name = "bazaar"
 
 include("bazaar-parser")
+include("bazaar-cli")


### PR DESCRIPTION
## Summary

- Adds `bazaar-cli` Kotlin/Native module that reads `.bzr` files and outputs parse results
- Supports `--format text|json`, `--check` (validation-only), and `--help` flags
- Exit codes: 0 (success), 1 (parse errors), 2 (CLI usage error)
- Multi-file JSON output wrapped in a valid JSON array

Closes #33

## Test plan

- [x] `bazaar-cli example.bzr` — text AST output
- [x] `--format json` — valid JSON output (single and multi-file)
- [x] `--check` on valid file — exit 0, no output
- [x] `--check` on invalid file — exit 1, diagnostics to stderr
- [x] `--help` — usage text to stdout, exit 0
- [x] Nonexistent file — error to stderr, exit 1
- [x] No args — usage error to stderr, exit 2
- [x] Existing parser tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)