### PR TITLE
Add unit tests for bazaar-cli module

### DIFF
--- a/bazaar-cli/build.gradle.kts
+++ b/bazaar-cli/build.gradle.kts
@@ -18,5 +18,11 @@ kotlin {
                 implementation(libs.kotlinx.io.core)
             }
         }
+
+        commonTest {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
     }
 }

--- a/bazaar-cli/src/commonTest/kotlin/com/bazaar/cli/ArgsTest.kt
+++ b/bazaar-cli/src/commonTest/kotlin/com/bazaar/cli/ArgsTest.kt
@@ -1,0 +1,104 @@
+package com.bazaar.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class ArgsTest {
+
+    @Test
+    fun helpLongFlag() {
+        assertIs<ArgsResult.Help>(parseArgs(arrayOf("--help")))
+    }
+
+    @Test
+    fun helpShortFlag() {
+        assertIs<ArgsResult.Help>(parseArgs(arrayOf("-h")))
+    }
+
+    @Test
+    fun formatTextExplicit() {
+        val result = parseArgs(arrayOf("--format", "text", "file.bzr"))
+        val success = assertIs<ArgsResult.Success>(result)
+        assertEquals(OutputFormat.TEXT, success.args.format)
+        assertEquals(listOf("file.bzr"), success.args.files)
+    }
+
+    @Test
+    fun formatJson() {
+        val result = parseArgs(arrayOf("--format", "json", "file.bzr"))
+        val success = assertIs<ArgsResult.Success>(result)
+        assertEquals(OutputFormat.JSON, success.args.format)
+    }
+
+    @Test
+    fun formatCaseInsensitive() {
+        val result = parseArgs(arrayOf("--format", "JSON", "file.bzr"))
+        val success = assertIs<ArgsResult.Success>(result)
+        assertEquals(OutputFormat.JSON, success.args.format)
+    }
+
+    @Test
+    fun checkFlag() {
+        val result = parseArgs(arrayOf("--check", "file.bzr"))
+        val success = assertIs<ArgsResult.Success>(result)
+        assertTrue(success.args.check)
+    }
+
+    @Test
+    fun multiplePositionalFiles() {
+        val result = parseArgs(arrayOf("a.bzr", "b.bzr"))
+        val success = assertIs<ArgsResult.Success>(result)
+        assertEquals(listOf("a.bzr", "b.bzr"), success.args.files)
+    }
+
+    @Test
+    fun combinedFlags() {
+        val result = parseArgs(arrayOf("--format", "json", "--check", "a.bzr", "b.bzr"))
+        val success = assertIs<ArgsResult.Success>(result)
+        assertEquals(OutputFormat.JSON, success.args.format)
+        assertTrue(success.args.check)
+        assertEquals(listOf("a.bzr", "b.bzr"), success.args.files)
+    }
+
+    @Test
+    fun noArgsReturnsError() {
+        val result = parseArgs(arrayOf())
+        val error = assertIs<ArgsResult.Error>(result)
+        assertEquals("No input files specified.", error.message)
+    }
+
+    @Test
+    fun unknownOptionReturnsError() {
+        val result = parseArgs(arrayOf("--unknown"))
+        assertIs<ArgsResult.Error>(result)
+    }
+
+    @Test
+    fun formatWithoutValueReturnsError() {
+        val result = parseArgs(arrayOf("--format"))
+        assertIs<ArgsResult.Error>(result)
+    }
+
+    @Test
+    fun formatInvalidValueReturnsError() {
+        val result = parseArgs(arrayOf("--format", "invalid", "file.bzr"))
+        assertIs<ArgsResult.Error>(result)
+    }
+
+    @Test
+    fun checkAloneNoFilesReturnsError() {
+        val result = parseArgs(arrayOf("--check"))
+        val error = assertIs<ArgsResult.Error>(result)
+        assertEquals("No input files specified.", error.message)
+    }
+
+    @Test
+    fun defaultsAreTextFormatAndNoCheck() {
+        val result = parseArgs(arrayOf("file.bzr"))
+        val success = assertIs<ArgsResult.Success>(result)
+        assertEquals(OutputFormat.TEXT, success.args.format)
+        assertEquals(false, success.args.check)
+    }
+}

--- a/bazaar-cli/src/commonTest/kotlin/com/bazaar/cli/FormattersTest.kt
+++ b/bazaar-cli/src/commonTest/kotlin/com/bazaar/cli/FormattersTest.kt
@@ -1,0 +1,150 @@
+package com.bazaar.cli
+
+import com.bazaar.parser.Diagnostic
+import com.bazaar.parser.ParseResult
+import com.bazaar.parser.Severity
+import com.bazaar.parser.ast.BazaarFile
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FormattersTest {
+
+    private val emptyAst = BazaarFile()
+
+    // --- formatTextResult ---
+
+    @Test
+    fun textSingleFileNoHeader() {
+        val result = ParseResult(emptyAst, emptyList())
+        val text = formatTextResult("file.bzr", result, multiFile = false)
+        assertTrue(!text.startsWith("---"))
+    }
+
+    @Test
+    fun textMultiFileHasHeader() {
+        val result = ParseResult(emptyAst, emptyList())
+        val text = formatTextResult("file.bzr", result, multiFile = true)
+        assertTrue(text.startsWith("--- file.bzr ---"))
+    }
+
+    @Test
+    fun textSuccessfulParseShowsAst() {
+        val result = ParseResult(emptyAst, emptyList())
+        val text = formatTextResult("file.bzr", result, multiFile = false)
+        assertContains(text, "BazaarFile")
+    }
+
+    @Test
+    fun textAstWithDiagnosticsConcatenated() {
+        val diags = listOf(Diagnostic(Severity.ERROR, 1, 5, "unexpected token"))
+        val result = ParseResult(emptyAst, diags)
+        val text = formatTextResult("file.bzr", result, multiFile = false)
+        assertContains(text, "BazaarFile")
+        assertContains(text, "ERROR 1:5 unexpected token")
+    }
+
+    @Test
+    fun textNullAstWithDiagnostics() {
+        val diags = listOf(Diagnostic(Severity.ERROR, 1, 1, "parse error"))
+        val result = ParseResult(null, diags)
+        val text = formatTextResult("file.bzr", result, multiFile = false)
+        assertContains(text, "ERROR 1:1 parse error")
+        assertTrue(!text.contains("BazaarFile"))
+    }
+
+    @Test
+    fun textNullAstEmptyDiagnostics() {
+        val result = ParseResult(null, emptyList())
+        val text = formatTextResult("file.bzr", result, multiFile = false)
+        assertEquals("", text)
+    }
+
+    // --- formatJsonResult ---
+
+    @Test
+    fun jsonSuccessfulParse() {
+        val result = ParseResult(emptyAst, emptyList())
+        val json = formatJsonResult("file.bzr", result)
+        assertContains(json, "\"status\": \"ok\"")
+        assertContains(json, "\"ast\":")
+        assertContains(json, "\"diagnostics\": []")
+    }
+
+    @Test
+    fun jsonNullAstWithErrors() {
+        val diags = listOf(Diagnostic(Severity.ERROR, 2, 3, "bad syntax"))
+        val result = ParseResult(null, diags)
+        val json = formatJsonResult("file.bzr", result)
+        assertContains(json, "\"status\": \"error\"")
+        assertTrue(!json.contains("\"ast\":"))
+        assertContains(json, "\"severity\": \"ERROR\"")
+        assertContains(json, "\"message\": \"bad syntax\"")
+        assertContains(json, "\"line\": 2")
+        assertContains(json, "\"column\": 3")
+    }
+
+    @Test
+    fun jsonNonNullAstWithErrors() {
+        val diags = listOf(Diagnostic(Severity.ERROR, 1, 1, "recovered"))
+        val result = ParseResult(emptyAst, diags)
+        val json = formatJsonResult("file.bzr", result)
+        assertContains(json, "\"status\": \"error\"")
+        assertContains(json, "\"ast\":")
+    }
+
+    @Test
+    fun jsonEscapesQuotesAndBackslashes() {
+        val result = ParseResult(null, emptyList())
+        val json = formatJsonResult("path\\to\\\"file\".bzr", result)
+        assertContains(json, "path\\\\to\\\\\\\"file\\\"")
+    }
+
+    @Test
+    fun jsonEscapesNewlines() {
+        val diags = listOf(Diagnostic(Severity.ERROR, 1, 1, "line1\nline2"))
+        val result = ParseResult(null, diags)
+        val json = formatJsonResult("file.bzr", result)
+        assertContains(json, "line1\\nline2")
+    }
+
+    @Test
+    fun jsonEscapesControlChars() {
+        val diags = listOf(Diagnostic(Severity.ERROR, 1, 1, "bell\u0007here"))
+        val result = ParseResult(null, diags)
+        val json = formatJsonResult("file.bzr", result)
+        assertContains(json, "bell\\u0007here")
+    }
+
+    @Test
+    fun jsonMultipleDiagnostics() {
+        val diags = listOf(
+            Diagnostic(Severity.ERROR, 1, 1, "first"),
+            Diagnostic(Severity.WARNING, 2, 5, "second"),
+            Diagnostic(Severity.ERROR, 3, 10, "third"),
+        )
+        val result = ParseResult(null, diags)
+        val json = formatJsonResult("file.bzr", result)
+        assertContains(json, "\"message\": \"first\"")
+        assertContains(json, "\"message\": \"second\"")
+        assertContains(json, "\"message\": \"third\"")
+        assertContains(json, "\"severity\": \"WARNING\"")
+    }
+
+    @Test
+    fun jsonWarningOnlyIsStatusOk() {
+        val diags = listOf(Diagnostic(Severity.WARNING, 1, 1, "just a warning"))
+        val result = ParseResult(emptyAst, diags)
+        val json = formatJsonResult("file.bzr", result)
+        assertContains(json, "\"status\": \"ok\"")
+        assertContains(json, "\"severity\": \"WARNING\"")
+    }
+
+    @Test
+    fun jsonFileFieldPresent() {
+        val result = ParseResult(emptyAst, emptyList())
+        val json = formatJsonResult("test.bzr", result)
+        assertContains(json, "\"file\": \"test.bzr\"")
+    }
+}


### PR DESCRIPTION
## Summary
- Add `commonTest` dependency on `kotlin("test")` to `bazaar-cli/build.gradle.kts`
- Add `ArgsTest` with 14 tests covering `parseArgs()` — help flags, format options, check flag, multiple files, combined flags, and all error cases
- Add `FormattersTest` with 14 tests covering `formatTextResult` and `formatJsonResult` — AST output, headers, diagnostics, JSON structure, string escaping, multi-diagnostic comma logic, and WARNING-only status

## Test plan
- [x] `./gradlew :bazaar-cli:allTests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)